### PR TITLE
fix(email): decode non-stdlib charset headers via CharsetReader

### DIFF
--- a/email/README.md
+++ b/email/README.md
@@ -20,7 +20,7 @@ Lenient parser that fixes common malformations encountered in real-world mail an
 | `AddressFrom(*mail.Address)`                | Convert a stdlib address.                          |
 | `a.Normalized()` / `Validate()` / `Valid()` | Validation variants.                               |
 | `a.Parse()`                                 | To `*mail.Address` via the package's lenient parser. |
-| `ParseAddress(str)`                         | Underlying parser; supports umlauts, RFC 2047 encoded-words, quoted names. |
+| `ParseAddress(str)`                         | Underlying parser; supports umlauts, RFC 2047 encoded-words (decoded across many charsets beyond Go's stdlib set), quoted names. |
 
 `AddressRegexp` is the compiled regex for the email-only form. It tolerates a wide range of umlaut/diacritic characters since real-world mail commonly violates strict RFC 2821/2822.
 
@@ -71,7 +71,7 @@ f, _ := os.Open("mail.eml")
 msg, err := email.ParseMIMEMessage(f)
 ```
 
-Backed by [`jhillyerd/enmime`](https://github.com/jhillyerd/enmime). For Microsoft TNEF (`winmail.dat`) attachments, see `parsetnef.go`.
+Backed by [`jhillyerd/enmime`](https://github.com/jhillyerd/enmime). RFC 2047 encoded-words in address headers (`From`, `To`, `Cc`, …) and extra (non-parsed) headers are decoded across many charsets beyond Go's stdlib defaults (us-ascii, utf-8, iso-8859-1) — e.g. ISO 8859-2 or Windows-1250 — so a `From` display name in such a charset no longer drops the whole message. For Microsoft TNEF (`winmail.dat`) attachments, see `parsetnef.go`.
 
 ## Attachment
 

--- a/email/parseaddress.go
+++ b/email/parseaddress.go
@@ -3,7 +3,6 @@ package email
 import (
 	"errors"
 	"fmt"
-	"mime"
 	"net/mail"
 	"regexp"
 	"slices"
@@ -143,8 +142,7 @@ func parseAddress(addr string) (mailAddress *mail.Address, unparsed string, err 
 		name = addr[i[4]:i[5]]
 	}
 	if name != "" {
-		var dec mime.WordDecoder
-		name, err = dec.DecodeHeader(name)
+		name, err = mimeHeaderDecoder.DecodeHeader(name)
 		if err != nil {
 			return nil, "", err
 		}

--- a/email/parseaddress_test.go
+++ b/email/parseaddress_test.go
@@ -56,6 +56,9 @@ var (
 
 		// RFC 2047 encoding
 		`=?utf-8?b?wqFIb2xhLCBzZcOxb3Ih?= <senor@hola.com>`: {Name: `¡Hola, señor!`, Address: "senor@hola.com"}, // mime.BEncoding.Encode("utf-8", `¡Hola, señor!`)
+		// Non-stdlib charsets decoded via the CharsetReader (Central-European senders)
+		`=?iso-8859-2?q?=A3ukasz?= <lukasz@example.pl>`:     {Name: `Łukasz`, Address: "lukasz@example.pl"}, // 0xA3 = Ł in ISO 8859-2
+		`=?windows-1250?Q?Wa=B3=EAsa?= <walesa@example.pl>`: {Name: `Wałęsa`, Address: "walesa@example.pl"}, // 0xB3 = ł, 0xEA = ę in Windows-1250
 
 		`'stupid@quoting.me'`:                         {Name: ``, Address: "stupid@quoting.me"},
 		`<'stupid@quoting.me'>`:                       {Name: ``, Address: "stupid@quoting.me"},

--- a/email/parsemime.go
+++ b/email/parsemime.go
@@ -7,11 +7,19 @@ import (
 	"mime"
 
 	"github.com/jhillyerd/enmime/v2"
+	"golang.org/x/net/html/charset"
 
 	"github.com/domonda/go-errs"
 	"github.com/domonda/go-types/nullable"
 	"github.com/domonda/go-types/strutil"
 )
+
+// mimeHeaderDecoder decodes RFC 2047 encoded-words in email headers.
+// The CharsetReader extends Go's stdlib mime support (us-ascii, utf-8,
+// iso-8859-1) to the full IANA charset set (iso-8859-2…16, windows-125x,
+// koi8, big5, shift_jis, …) so that headers from senders using other
+// charsets are decoded instead of failing the whole message.
+var mimeHeaderDecoder = &mime.WordDecoder{CharsetReader: charset.NewReaderLabel}
 
 // ParseMIMEMessage parses a MIME email message read from the passed reader.
 func ParseMIMEMessage(reader io.Reader) (msg *Message, err error) {
@@ -84,11 +92,10 @@ func ParseMIMEMessage(reader io.Reader) (msg *Message, err error) {
 		msg.Bcc = msg.Bcc.Append(addrs...)
 	}
 
-	dec := new(mime.WordDecoder)
 	for key, values := range envelope.Root.Header {
 		if IsExtraHeader(key) {
 			for _, value := range values {
-				decodedvalue, err := dec.DecodeHeader(value)
+				decodedvalue, err := mimeHeaderDecoder.DecodeHeader(value)
 				if err != nil {
 					// ignore decoding issues, just use value
 					msg.ExtraHeader.Add(key, value)

--- a/email/parsemime_test.go
+++ b/email/parsemime_test.go
@@ -1,0 +1,69 @@
+package email_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/domonda/go-types/email"
+	"github.com/stretchr/testify/require"
+)
+
+// rawMessage joins the passed header/body lines with CRLF as required by RFC 822.
+func rawMessage(lines ...string) []byte {
+	return []byte(strings.Join(lines, "\r\n"))
+}
+
+// TestParseMIMEMessage_NonStdlibCharset is a regression test for the bug where
+// a header using a charset outside Go's stdlib mime support (us-ascii, utf-8,
+// iso-8859-1) caused the whole message to be dropped with
+// "mime: unhandled charset ...".
+//
+// It exercises the full ParseMIMEMessage pipeline. Note that enmime decodes
+// the addressed/structured headers (From, To, Cc, Subject, ...) itself via the
+// same x/net charset reader, so those assertions verify end-to-end correctness.
+// The extra-header loop in ParseMIMEMessage, however, decodes the *raw*
+// envelope.Root.Header values with our mimeHeaderDecoder, so the X-Original-From
+// assertion is the one that specifically guards the CharsetReader fix
+// (it fails with the plain stdlib mime.WordDecoder).
+func TestParseMIMEMessage_NonStdlibCharset(t *testing.T) {
+	raw := rawMessage(
+		`From: =?iso-8859-2?Q?=A3ukasz?= <lukasz@example.pl>`,   // 0xA3 = Ł in ISO 8859-2
+		`To: =?windows-1250?Q?Wa=B3=EAsa?= <walesa@example.pl>`, // 0xB3 = ł, 0xEA = ę in Windows-1250
+		`Subject: =?iso-8859-2?Q?=A3ukasz?=`,
+		`Date: Thu, 22 Jan 2026 16:21:11 +0100`,
+		`X-Original-From: =?iso-8859-2?Q?=A3ukasz?= <lukasz@example.pl>`,
+		`X-Bogus-Charset: =?made-up-9999?Q?abc?=`, // unsupported charset must not drop the message
+		`Content-Type: text/plain; charset=utf-8`,
+		``,
+		`Body text.`,
+	)
+
+	msg, err := email.ParseMessage(raw)
+	require.NoError(t, err, "message with a non-stdlib charset header must not be dropped")
+
+	// From header path, decoded from ISO 8859-2.
+	fromName, err := msg.From.NamePart()
+	require.NoError(t, err)
+	require.Equal(t, "Łukasz", fromName)
+	fromAddr, err := msg.From.AddressPartString()
+	require.NoError(t, err)
+	require.Equal(t, "lukasz@example.pl", fromAddr)
+
+	// To header path, decoded from Windows-1250.
+	toAddrs, err := msg.To.Parse()
+	require.NoError(t, err)
+	require.Len(t, toAddrs, 1)
+	require.Equal(t, "Wałęsa", toAddrs[0].Name)
+	require.Equal(t, "walesa@example.pl", toAddrs[0].Address)
+
+	// Subject decoded from ISO 8859-2.
+	require.Equal(t, "Łukasz", msg.Subject)
+
+	// Extra-header decode loop reads the raw header and decodes it with our
+	// mimeHeaderDecoder — this assertion fails without the CharsetReader fix.
+	require.Equal(t, []string{`Łukasz <lukasz@example.pl>`}, msg.ExtraHeader["X-Original-From"])
+
+	// An unsupported charset must degrade gracefully: the extra-header loop
+	// ignores the decode error and keeps the raw value instead of failing.
+	require.Equal(t, []string{`=?made-up-9999?Q?abc?=`}, msg.ExtraHeader["X-Bogus-Charset"])
+}


### PR DESCRIPTION
Go's stdlib `mime.WordDecoder` only decodes us-ascii, utf-8, and iso-8859-1, so an email whose `From` (or other) header carries an RFC 2047 encoded-word in another charset (e.g. iso-8859-2 or windows-1250 from Central-European senders) failed with `mime: unhandled charset ...` and the whole message was dropped. This gives a shared `mimeHeaderDecoder` a `CharsetReader` (`golang.org/x/net/html/charset.NewReaderLabel`, already a direct dep and the one enmime uses) covering the full IANA charset set, wired into both `parseAddress` and the `ParseMIMEMessage` extra-header loop. Adds address-level cases (iso-8859-2, windows-1250) plus an end-to-end `ParseMIMEMessage` test that also verifies graceful degradation on an unsupported charset, and updates `email/README.md` to document the behavior. The full `./email/` suite passes under `-race`, and `go vet` is clean.
