### PR TITLE
feat(email): return partial results with joined errors on parse failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ func main() {
     fmt.Printf("Normalized: %s\n", addr)
     
     // Create address list
-    list := email.AddressList{addr, email.Address("jane@example.com")}
+    list := email.AddressListJoin(addr, email.Address("jane@example.com"))
     fmt.Printf("Address list: %v\n", list)
 }
 ```

--- a/email/README.md
+++ b/email/README.md
@@ -32,6 +32,8 @@ type AddressList string // comma-separated
 
 `NormalizeAddressList(str)` parses, normalizes, and de-duplicates by normalized address part. Methods: `Normalized()`, `Validate()`, plus `ParseAddressList(str)` for the parsed slice.
 
+`ParseAddressList(str)` and `Split()` (on both `AddressList` and `NullableAddressList`) are lenient: when an entry is malformed the parser skips past the next comma and keeps going, so well-formed entries elsewhere in the list are still returned. The failures are collected into a single `errors.Join` error, so a non-nil error can accompany a non-empty result; treat the error as fatal only when you need a strictly valid list. Empty input and the `undisclosed-recipients` / `withheld-recipients` placeholders parse as an empty list without an error.
+
 ## AddressSet
 
 ```go
@@ -71,7 +73,7 @@ f, _ := os.Open("mail.eml")
 msg, err := email.ParseMIMEMessage(f)
 ```
 
-Backed by [`jhillyerd/enmime`](https://github.com/jhillyerd/enmime). RFC 2047 encoded-words in address headers (`From`, `To`, `Cc`, …) and extra (non-parsed) headers are decoded across many charsets beyond Go's stdlib defaults (us-ascii, utf-8, iso-8859-1) — e.g. ISO 8859-2 or Windows-1250 — so a `From` display name in such a charset no longer drops the whole message. For Microsoft TNEF (`winmail.dat`) attachments, see `parsetnef.go`.
+Backed by [`jhillyerd/enmime`](https://github.com/jhillyerd/enmime). RFC 2047 encoded-words in address headers (`From`, `To`, `Cc`, …) and extra (non-parsed) headers are decoded across many charsets beyond Go's stdlib defaults (us-ascii, utf-8, iso-8859-1) — e.g. ISO 8859-2 or Windows-1250 — so a `From` display name in such a charset no longer drops the whole message. More broadly, as long as the envelope is readable `ParseMIMEMessage` returns a `*Message` with all usable data even when individual headers (`Date`, `From`, `To`) can't be parsed; those failures are collected into a single `errors.Join` error returned alongside the message, so a non-nil error can accompany a usable result. For Microsoft TNEF (`winmail.dat`) attachments, see `parsetnef.go`.
 
 ## Attachment
 

--- a/email/addresslist.go
+++ b/email/addresslist.go
@@ -97,20 +97,21 @@ func (l AddressList) Parse() ([]*mail.Address, error) {
 }
 
 // Split converts the AddressList to a slice of Address values.
-// Returns nil if the list is empty or invalid.
+//
+// All successfully parsed addresses are returned even when other
+// addresses in the list can't be parsed. Parsing errors are collected
+// and returned joined (see ParseAddressList), so a non-nil error can
+// accompany a non-empty result slice. Returns nil if the list is empty.
 func (l AddressList) Split() ([]Address, error) {
 	parsed, err := l.Parse()
-	if err != nil {
-		return nil, err
-	}
 	if len(parsed) == 0 {
-		return nil, nil
+		return nil, err
 	}
 	a := make([]Address, len(parsed))
 	for i, p := range parsed {
 		a[i] = AddressFrom(p)
 	}
-	return a, nil
+	return a, err
 }
 
 // UniqueAddressParts returns an AddressSet containing the unique normalized

--- a/email/addresslist_test.go
+++ b/email/addresslist_test.go
@@ -41,6 +41,9 @@ func TestAddressList_Split(t *testing.T) {
 		{l: ``, want: nil},
 		{l: `<hello@example.com>,`, want: []Address{`hello@example.com`}},
 		{l: `<Hello@example.com>, World@example.com`, want: []Address{`hello@example.com`, `world@example.com`}},
+		// Partial result: parsable addresses are returned alongside the error.
+		{l: `alice@example.com, broken address, bob@example.com`, want: []Address{`alice@example.com`, `bob@example.com`}, wantErr: true},
+		{l: `@broken`, want: nil, wantErr: true},
 	}
 	for _, tt := range tests {
 		t.Run(string(tt.l), func(t *testing.T) {

--- a/email/nullableaddresslist.go
+++ b/email/nullableaddresslist.go
@@ -60,6 +60,10 @@ func (n NullableAddressList) Parse() ([]*mail.Address, error) {
 
 // Split converts the NullableAddressList to a slice of Address values,
 // or returns nil if the list is null.
+//
+// Like AddressList.Split it returns all successfully parsed addresses
+// even when other addresses in the list can't be parsed, with the
+// parsing errors collected and returned joined.
 func (n NullableAddressList) Split() ([]Address, error) {
 	if n.IsNull() {
 		return nil, nil

--- a/email/parseaddress.go
+++ b/email/parseaddress.go
@@ -197,8 +197,16 @@ func parseAddress(addr string) (mailAddress *mail.Address, unparsed string, err 
 // ParseAddressList parses an email address list less strict
 // than the standard net/mail.ParseAddressList function
 // fixing malformed addresses and lower cases the address part.
-// ParseAddressList returns an error if list does not contain
-// at least one address.
+//
+// All successfully parsed addresses are returned even when other
+// addresses in the list can't be parsed. Parsing errors are collected
+// and returned joined via errors.Join, so a non-nil error can accompany
+// a non-empty result slice. Callers that need a strictly valid list
+// should treat any non-nil error as a failure.
+//
+// The empty list and the common "undisclosed-recipients" /
+// "withheld-recipients" placeholders are parsed as an empty list
+// without an error.
 func ParseAddressList(list string) (addrs []*mail.Address, err error) {
 	list = strings.TrimRight(sanitizeAddr(list), ", ")
 
@@ -211,23 +219,37 @@ func ParseAddressList(list string) (addrs []*mail.Address, err error) {
 		return nil, nil
 	}
 
-	mailAddress, unparsed, err := parseAddress(list)
-	if err != nil {
-		return nil, fmt.Errorf("could not parse email address list '%s', because of: %w", list, err)
-	}
-	addrs = append(addrs, mailAddress)
-
-	for unparsed != "" {
-		if unparsed[0] != ',' {
-			return nil, fmt.Errorf("expected ',' after parsing email address in unparsed part: '%s' | full list: '%s'", unparsed, list)
-		}
-		unparsed = strings.TrimLeft(unparsed[1:], " ")
-		mailAddress, unparsed, err = parseAddress(unparsed)
-		if err != nil {
-			return nil, fmt.Errorf("could not parse email address list '%s', because of: %w", list, err)
+	var errList []error
+	for remaining := list; remaining != ""; {
+		mailAddress, unparsed, parseErr := parseAddress(remaining)
+		if parseErr != nil {
+			errList = append(errList, fmt.Errorf("could not parse email address list '%s', because of: %w", list, parseErr))
+			// Recover by skipping past the next separator so the
+			// remaining addresses can still be parsed and returned.
+			_, after, found := strings.Cut(remaining, ",")
+			if !found {
+				break
+			}
+			remaining = strings.TrimLeft(after, " ")
+			continue
 		}
 		addrs = append(addrs, mailAddress)
+
+		unparsed = strings.TrimLeft(unparsed, " ")
+		if unparsed == "" {
+			break
+		}
+		if unparsed[0] != ',' {
+			errList = append(errList, fmt.Errorf("expected ',' after parsing email address in unparsed part: '%s' | full list: '%s'", unparsed, list))
+			_, after, found := strings.Cut(unparsed, ",")
+			if !found {
+				break
+			}
+			remaining = strings.TrimLeft(after, " ")
+			continue
+		}
+		remaining = strings.TrimLeft(unparsed[1:], " ")
 	}
 
-	return addrs, nil
+	return addrs, errors.Join(errList...)
 }

--- a/email/parseaddress_test.go
+++ b/email/parseaddress_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/domonda/go-types/strutil"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -359,4 +360,40 @@ func TestParseAddressList(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestParseAddressList_PartialResult verifies that ParseAddressList collects
+// parsing errors, joins them, and still returns all addresses that could be
+// parsed even when other entries in the list are invalid.
+func TestParseAddressList_PartialResult(t *testing.T) {
+	t.Run("invalid entry between valid ones", func(t *testing.T) {
+		addrs, err := ParseAddressList("alice@example.com, not a valid address, bob@example.com")
+		require.Error(t, err, "the invalid middle entry must produce an error")
+
+		got := make([]string, len(addrs))
+		for i, a := range addrs {
+			got[i] = a.Address
+		}
+		require.Equal(t, []string{"alice@example.com", "bob@example.com"}, got,
+			"the valid addresses must still be returned")
+	})
+
+	t.Run("leading invalid entry", func(t *testing.T) {
+		addrs, err := ParseAddressList("@broken, valid@example.com")
+		require.Error(t, err)
+		require.Len(t, addrs, 1)
+		require.Equal(t, "valid@example.com", addrs[0].Address)
+	})
+
+	t.Run("all valid has no error", func(t *testing.T) {
+		addrs, err := ParseAddressList("alice@example.com, bob@example.com")
+		require.NoError(t, err)
+		require.Len(t, addrs, 2)
+	})
+
+	t.Run("all invalid returns nil and error", func(t *testing.T) {
+		addrs, err := ParseAddressList("@broken, also broken")
+		require.Error(t, err)
+		require.Nil(t, addrs)
+	})
 }

--- a/email/parsemime.go
+++ b/email/parsemime.go
@@ -2,6 +2,7 @@ package email
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"mime"
@@ -22,6 +23,12 @@ import (
 var mimeHeaderDecoder = &mime.WordDecoder{CharsetReader: charset.NewReaderLabel}
 
 // ParseMIMEMessage parses a MIME email message read from the passed reader.
+//
+// As long as the underlying envelope can be read, a non-nil message with
+// all usable data is returned even if individual headers (Date, From, To)
+// can't be parsed. Such parsing errors are collected and returned joined
+// via errors.Join alongside the message, so callers can use the partial
+// result while still being able to inspect what went wrong.
 func ParseMIMEMessage(reader io.Reader) (msg *Message, err error) {
 	defer errs.WrapWithFuncParams(&err, reader)
 
@@ -41,15 +48,21 @@ func ParseMIMEMessage(reader io.Reader) (msg *Message, err error) {
 		BodyHTML:    nullable.TrimmedStringFrom(envelope.HTML),
 		ExtraHeader: make(Header),
 	}
+	// parseErrs collects non-fatal header parsing errors so that a message
+	// with usable data is still returned together with the joined errors.
+	var parseErrs []error
+
 	if date := envelope.GetHeader("Date"); date != "" {
 		msg.Date, err = parseDate(date)
 		if err != nil {
-			return nil, err
+			parseErrs = append(parseErrs, fmt.Errorf("can't parse email header 'Date': %w", err))
+			msg.Date = nil
 		}
 	}
 	msg.From, err = NormalizedAddress(envelope.GetHeader("From"))
 	if err != nil {
-		return nil, fmt.Errorf("can't parse email header 'From': %w", err)
+		parseErrs = append(parseErrs, fmt.Errorf("can't parse email header 'From': %w", err))
+		msg.From = ""
 	}
 	msg.ReplyTo, err = NormalizedNullableAddress(envelope.GetHeader("Reply-To"))
 	if err != nil {
@@ -58,37 +71,33 @@ func ParseMIMEMessage(reader io.Reader) (msg *Message, err error) {
 		msg.ReplyTo = NullableAddress("")
 	}
 	for _, to := range envelope.GetHeaderValues("To") {
+		// Split returns all parsable addresses even when others fail,
+		// so keep the usable ones and collect the error.
 		addrs, err := AddressList(to).Split()
 		if err != nil {
-			return nil, fmt.Errorf("can't parse email header 'To': %w", err)
+			parseErrs = append(parseErrs, fmt.Errorf("can't parse email header 'To': %w", err))
 		}
 		msg.To = msg.To.Append(addrs...)
 	}
 	for _, deliveredTo := range envelope.GetHeaderValues("Delivered-To") {
-		addrs, err := AddressList(deliveredTo).Split()
-		if err != nil {
-			// intentionally ignoring parsing issues with nullable lists
-			// we've seen weird and unparsable values
-			continue
-		}
+		// intentionally ignoring parsing issues with nullable lists
+		// (we've seen weird and unparsable values) but keep the
+		// addresses that could be parsed
+		addrs, _ := AddressList(deliveredTo).Split()
 		msg.DeliveredTo = msg.DeliveredTo.Append(addrs...)
 	}
 	for _, cc := range envelope.GetHeaderValues("Cc") {
-		addrs, err := AddressList(cc).Split()
-		if err != nil {
-			// intentionally ignoring parsing issues with nullable lists
-			// we've seen weird and unparsable values
-			continue
-		}
+		// intentionally ignoring parsing issues with nullable lists
+		// (we've seen weird and unparsable values) but keep the
+		// addresses that could be parsed
+		addrs, _ := AddressList(cc).Split()
 		msg.Cc = msg.Cc.Append(addrs...)
 	}
 	for _, bcc := range envelope.GetHeaderValues("Bcc") {
-		addrs, err := AddressList(bcc).Split()
-		if err != nil {
-			// intentionally ignoring parsing issues with nullable lists
-			// we've seen weird and unparsable values
-			continue
-		}
+		// intentionally ignoring parsing issues with nullable lists
+		// (we've seen weird and unparsable values) but keep the
+		// addresses that could be parsed
+		addrs, _ := AddressList(bcc).Split()
 		msg.Bcc = msg.Bcc.Append(addrs...)
 	}
 
@@ -136,7 +145,7 @@ func ParseMIMEMessage(reader io.Reader) (msg *Message, err error) {
 		})
 	}
 
-	return msg, nil
+	return msg, errors.Join(parseErrs...)
 }
 
 // ParseMIMEMessageBytes parses a MIME email message from the passed bytes.

--- a/email/parsemime_test.go
+++ b/email/parsemime_test.go
@@ -67,3 +67,34 @@ func TestParseMIMEMessage_NonStdlibCharset(t *testing.T) {
 	// ignores the decode error and keeps the raw value instead of failing.
 	require.Equal(t, []string{`=?made-up-9999?Q?abc?=`}, msg.ExtraHeader["X-Bogus-Charset"])
 }
+
+// TestParseMIMEMessage_PartialResult verifies that a message with usable data
+// is returned together with the joined header parsing errors instead of being
+// dropped entirely when individual headers (Date, From, To) can't be parsed.
+func TestParseMIMEMessage_PartialResult(t *testing.T) {
+	raw := rawMessage(
+		`From: not an email address`,
+		`To: good@example.com, this is broken`,
+		`Subject: Partial parse`,
+		`Date: definitely not a date`,
+		`Content-Type: text/plain; charset=utf-8`,
+		``,
+		`Body text.`,
+	)
+
+	msg, err := email.ParseMessage(raw)
+	require.Error(t, err, "unparseable Date/From/To headers must surface a joined error")
+	require.NotNil(t, msg, "a message with usable data must still be returned")
+
+	// Usable data is preserved instead of dropping the whole message.
+	require.Equal(t, "Partial parse", msg.Subject)
+	require.Equal(t, "Body text.", strings.TrimSpace(msg.Body))
+
+	// Unparseable single-value headers are left unset.
+	require.Empty(t, string(msg.From))
+	require.Nil(t, msg.Date)
+
+	// The valid address from the To list is kept even though the list also
+	// contained an unparseable entry.
+	require.Equal(t, email.AddressList("good@example.com"), msg.To)
+}


### PR DESCRIPTION
`ParseMIMEMessage` now returns a non-nil message with all usable data instead of dropping the whole message when an individual header (`Date`, `From`, `To`) can't be parsed; these errors are collected and returned joined via `errors.Join`. `ParseAddressList` likewise collects parse errors, joins them, and still returns every address it could parse — recovering past malformed entries instead of bailing on the first one. `AddressList.Split` and `NullableAddressList.Split` follow the same pattern, returning the parsable addresses alongside the joined error (the `To`/`Delivered-To`/`Cc`/`Bcc` loops keep using `Split`, now keeping their usable addresses). Existing callers that treat any non-nil error as failure keep their behavior, since a non-nil error still signals a non-strictly-valid list. Added tests covering partial-result parsing for `ParseAddressList`, `Split`, and `ParseMIMEMessage`.


## Documentation

Docs updated to match the partial-result / joined-error behavior shipped here (behavior change, no new exported API).

- `email/README.md` — AddressList section: documented that `ParseAddressList` and `Split()` (on both `AddressList` and `NullableAddressList`) recover past a malformed entry by skipping to the next comma, return the parsable addresses, and collect failures into a single `errors.Join` error, so a non-nil error can accompany a non-empty result. Noted that empty input and the `undisclosed-recipients` / `withheld-recipients` placeholders parse as an empty list without error.
- `email/README.md` — Parsing wire-format mail section: documented that `ParseMIMEMessage` returns a `*Message` with usable data even when `Date`/`From`/`To` headers fail to parse, with those errors joined via `errors.Join` alongside the message.
- `README.md` (root) — fixed a non-compiling example: `email.AddressList{...}` (a `string` type) replaced with `email.AddressListJoin(...)`.

### Documentation debt
- `ParseMIMEMessageBytes` and the MIME-path `ParseMessage` share the same partial-result behavior but aren't individually documented; the README documents `ParseMIMEMessage` as the entry point. Low priority.
- No `CHANGELOG.md` and no version tags exist yet (both tracked in `TODOS.md` as v1.0 blockers); this behavior change should get a CHANGELOG entry once one exists.
