### PR TITLE
feat(money): add exact fixed-point DecimalAmount with max-precision arithmetic

### DIFF
--- a/money/README.md
+++ b/money/README.md
@@ -1,6 +1,6 @@
 # money
 
-Monetary amounts, ISO 4217 currency codes, currency+amount pairs, and conversion rates — with locale-aware parsing/formatting and SQL/JSON integration.
+Monetary amounts (float64 and exact fixed-point), ISO 4217 currency codes, currency+amount pairs, and conversion rates — with locale-aware parsing/formatting and SQL/JSON integration.
 
 ```
 import "github.com/domonda/go-types/money"
@@ -30,6 +30,40 @@ type NullableAmount = nullable.Type[Amount]
 `NullableAmount` is `nullable.Type[Amount]`. Constructors `NullableAmountFrom(v)` and `NullableAmountFromPtr(*Amount)`.
 
 `AmountFinder` matches localized amount patterns (`-?\d+,\d{2}`, `-?\d{1,3}(?:\.\d{3})*(?:,\d{2})`, etc.); `StringIsAmount(str, acceptInt)` is the boolean shortcut.
+
+## DecimalAmount
+
+```go
+type DecimalAmount struct{ /* packed int64 */ }
+type NullableDecimalAmount = nullable.Type[DecimalAmount]
+```
+
+Exact fixed-point money, an alternative to the `float64`-based `Amount`. The value is `Coefficient × 10^-Scale`, packed into a single `int64`: the low 5 bits hold the scale (0–18) and the high 59 bits the signed coefficient (~18 significant digits, ±2.88×10¹⁷). Finite values are exact — `0.10` and `99999999999999.99` keep every digit — and the per-value scale is preserved, so `1.50` (scale 2) and `1.5` (scale 1) are distinct representations of the same value.
+
+The reserved scale `31` encodes the non-finite states **NaN**, **+Inf** and **-Inf**. Arithmetic never panics on data: overflow yields ±Inf, `x/0` yields ±Inf (or NaN for `0/0`), and NaN propagates like IEEE floating point. Only misuse — an out-of-range `scale`/`decimals` argument — panics.
+
+Implements `fmt.Stringer`, `fmt.GoStringer`, `fmt.Formatter`, `driver.Valuer`, `sql.Scanner`, `json.Marshaler`/`Unmarshaler`, `encoding.TextMarshaler`/`Unmarshaler`, `encoding.BinaryMarshaler`/`Unmarshaler` and `JSONSchema`.
+
+| Function / Method                                  | Description                                        |
+|----------------------------------------------------|----------------------------------------------------|
+| `NewDecimalAmount(coeff, scale)`                   | From integer coefficient and scale (panics if out of range). |
+| `ParseDecimalAmount(str, decimals...)`             | Exact locale-aware parse (no `float64` round-trip). Reads `NaN`/`Inf`/`Infinity`. |
+| `DecimalAmountFromInt(i)` / `FromFloat(f, scale, mode)` / `FromAmount(a, scale, mode)` | Conversions. |
+| `DecimalAmountNaN()` / `DecimalAmountInf(sign)`    | Non-finite constructors.                           |
+| `a.Coefficient()` / `a.Scale()`                    | Raw parts (finite values only).                    |
+| `a.Add(b)` / `a.Sub(b)` / `a.MulInt(n)` / `a.MulInt64(n)` | Exact arithmetic; overflow → ±Inf.          |
+| `a.Mul(b, mode)` / `a.Div(b, mode)`                | 128-bit exact multiply/divide, rounded to `a`'s scale. |
+| `a.RoundToDecimals(n, mode)` / `RoundToCents(mode)` / `RoundToInt(mode)` | Rounding with an explicit `RoundingMode`. |
+| `a.MultipliedByRate(r, scale, mode)` / `DividedByRate` / `Percentage` | Apply a `float64` `Rate`.        |
+| `a.Cmp(b)` / `a.Equal(b)` / `a.Sign()` / `a.IsZero()` | Value comparison (total order `-Inf < finite < +Inf < NaN`). |
+| `a.IsFinite()` / `a.Valid()` / `a.IsNaN()` / `a.IsInf(sign)` | Non-finite tests (mirror `Amount`).      |
+| `a.Abs()` / `a.Neg()`                              | Sign helpers (propagate non-finite).               |
+| `a.Float()` / `a.Amount()`                         | Back to `float64` / `Amount` (may lose precision). |
+| `a.String()` / `a.FormatSep(thousands, decimal)`   | Exact rendering; `fmt` verbs via `fmt.Formatter` (`%v %s %q %f %d`, flags). |
+
+`RoundingMode`: `RoundHalfAwayFromZero` (zero value / default), `RoundHalfToEven`, `RoundHalfUp`, `RoundHalfDown`, `RoundDown`, `RoundUp`, `RoundFloor`, `RoundCeil`.
+
+`NullableDecimalAmount` is `nullable.Type[DecimalAmount]`. Constructors `NullableDecimalAmountFrom(v)` and `NullableDecimalAmountFromPtr(*DecimalAmount)`.
 
 ## Currency
 
@@ -62,6 +96,17 @@ type CurrencyAmount struct {
 Constructors: `NewCurrencyAmount`, `CurrencyAmountUSD`, `CurrencyAmountEUR`, `CurrencyAmountCHF`, `CurrencyAmountGBP`, `CurrencyAmountJPY`.
 
 `ParseCurrencyAmount(str, decimals...)` accepts `"EUR 1.234,56"`, `"1,234.56 USD"`, etc. — it finds the first/last separator between letters and digits, normalizes each part, and validates decimal counts if an allowlist is given.
+
+## CurrencyDecimalAmount
+
+```go
+type CurrencyDecimalAmount struct {
+    Currency Currency
+    Amount   DecimalAmount
+}
+```
+
+The exact counterpart of `CurrencyAmount`, pairing a `Currency` with a `DecimalAmount`. Same shape — constructors `NewCurrencyDecimalAmount`, `CurrencyDecimalAmountUSD/EUR/CHF/GBP/JPY`, and `ParseCurrencyDecimalAmount(str, decimals...)` — plus `Format`, `String`, `GoString`, `ScanString`, `sql.Scanner`/`driver.Valuer`. Formatting uses the amount's own scale rather than forcing two decimals, and `ca.CurrencyAmount()` bridges back to the `float64` form.
 
 ## Rate
 

--- a/money/README.md
+++ b/money/README.md
@@ -22,7 +22,7 @@ type NullableAmount = nullable.Type[Amount]
 | `a.Cents()`                                        | Rounded to integer cents (`int64`).                |
 | `a.WithinOneCent(b)`                               | True if `abs(a - b)` ≤ 0.01.                       |
 | `a.RoundToInt()` / `RoundToCents()` / `RoundToDecimals(n)` | Rounding helpers.                                  |
-| `a.Format(...)`                                    | Wraps `float.Format` for locale output.            |
+| `a.FormatSep(...)`                                 | Wraps `float.Format` for locale output.            |
 | `a.Valid()`                                        | Not NaN, not Inf.                                  |
 | `a.Ptr()`                                          | Pointer to a copy of the value.                    |
 | `a.ScanString(src, validate)`                      | Assign from string, validating only if asked.      |
@@ -48,13 +48,13 @@ Implements `fmt.Stringer`, `fmt.GoStringer`, `fmt.Formatter`, `driver.Valuer`, `
 |----------------------------------------------------|----------------------------------------------------|
 | `NewDecimalAmount(coeff, scale)`                   | From integer coefficient and scale (panics if out of range). |
 | `ParseDecimalAmount(str, decimals...)`             | Exact locale-aware parse (no `float64` round-trip). Reads `NaN`/`Inf`/`Infinity`. |
-| `DecimalAmountFromInt(i)` / `FromFloat(f, scale, mode)` / `FromAmount(a, scale, mode)` | Conversions. |
+| `DecimalAmountFrom(v)`                             | Generic conversion from integer types (exact, scale 0) and float types incl. `Amount`/`Rate` (shortest exact decimal of the float value). |
 | `DecimalAmountNaN()` / `DecimalAmountInf(sign)`    | Non-finite constructors.                           |
 | `a.Coefficient()` / `a.Scale()`                    | Raw parts (finite values only).                    |
-| `a.Add(b)` / `a.Sub(b)` / `a.MulInt(n)` / `a.MulInt64(n)` | Exact arithmetic; overflow → ±Inf.          |
-| `a.Mul(b, mode)` / `a.Div(b, mode)`                | 128-bit exact multiply/divide, rounded to `a`'s scale. |
+| `a.Add(b)` / `a.Sub(b)` / `a.MulInt(n)` / `a.MulInt64(n)` | Exact arithmetic; integer overflow → ±Inf.  |
+| `a.Mul(b, mode)` / `a.Div(b, mode)`                | 128-bit exact multiply/divide at full result precision; `mode` only applies when the exact result exceeds the representable precision. |
 | `a.RoundToDecimals(n, mode)` / `RoundToCents(mode)` / `RoundToInt(mode)` | Rounding with an explicit `RoundingMode`. |
-| `a.MultipliedByRate(r, scale, mode)` / `DividedByRate` / `Percentage` | Apply a `float64` `Rate`.        |
+| `a.MultipliedByRate(r)` / `DividedByRate(r)` / `Percentage(p)` | Apply a `float64` `Rate`; result is the exact shortest decimal of the `float64` result. |
 | `a.Cmp(b)` / `a.Equal(b)` / `a.Sign()` / `a.IsZero()` | Value comparison (total order `-Inf < finite < +Inf < NaN`). |
 | `a.IsFinite()` / `a.Valid()` / `a.IsNaN()` / `a.IsInf(sign)` | Non-finite tests (mirror `Amount`).      |
 | `a.Abs()` / `a.Neg()`                              | Sign helpers (propagate non-finite).               |
@@ -63,7 +63,28 @@ Implements `fmt.Stringer`, `fmt.GoStringer`, `fmt.Formatter`, `driver.Valuer`, `
 
 `RoundingMode`: `RoundHalfAwayFromZero` (zero value / default), `RoundHalfToEven`, `RoundHalfUp`, `RoundHalfDown`, `RoundDown`, `RoundUp`, `RoundFloor`, `RoundCeil`.
 
-`NullableDecimalAmount` is `nullable.Type[DecimalAmount]`. Constructors `NullableDecimalAmountFrom(v)` and `NullableDecimalAmountFromPtr(*DecimalAmount)`.
+### Calculate exactly, round once at the end
+
+Arithmetic results carry the scale that holds the full precision of the result: `Add`/`Sub` use the larger operand scale, `Mul` the sum of the operand scales, and `Div` extends the scale as far as needed (up to the 18-place maximum for non-terminating quotients). So a chain of calculations loses no data along the way — round to the final precision (typically 2 decimal places for cents, or 4 in accounting) exactly once, at the end:
+
+```go
+price := money.NewDecimalAmount(1999, 2) // 19.99 per unit
+qty := money.DecimalAmountFrom(7)
+vatFactor := money.NewDecimalAmount(119, 2) // 1.19 → 19% VAT
+
+net := price.Mul(qty, money.RoundHalfAwayFromZero)   // 139.93   (scale 2, exact)
+gross := net.Mul(vatFactor, money.RoundHalfAwayFromZero) // 166.5167 (scale 4, exact)
+perMonth := gross.Div(money.DecimalAmountFrom(12), money.RoundHalfAwayFromZero)
+// 13.8763916666666667 — non-terminating, so it is rounded at the
+// maximum representable precision (this is the only step that rounds)
+
+cents := perMonth.RoundToCents(money.RoundHalfToEven)        // 13.88
+account := perMonth.RoundToDecimals(4, money.RoundHalfToEven) // 13.8764
+```
+
+Had every step been rounded to cents instead, the monthly amount would come out as `166.52 / 12 → 13.88` here, but chains of such intermediate roundings drift by whole cents; keeping full precision until the final rounding avoids that. The float-based `MultipliedByRate`/`DividedByRate`/`Percentage` follow the same pattern: they return the exact shortest decimal of the `float64` result (e.g. `0.10 × Rate(3)` → `0.30000000000000004`) for you to round once at the end.
+
+`NullableDecimalAmount` is `nullable.Type[DecimalAmount]`. Wrap a value with `a.Nullable()` or a pointer with `NullableDecimalAmountFromPtr(*DecimalAmount)` (nil → null).
 
 ## Currency
 
@@ -106,7 +127,7 @@ type CurrencyDecimalAmount struct {
 }
 ```
 
-The exact counterpart of `CurrencyAmount`, pairing a `Currency` with a `DecimalAmount`. Same shape — constructors `NewCurrencyDecimalAmount`, `CurrencyDecimalAmountUSD/EUR/CHF/GBP/JPY`, and `ParseCurrencyDecimalAmount(str, decimals...)` — plus `Format`, `String`, `GoString`, `ScanString`, `sql.Scanner`/`driver.Valuer`. Formatting uses the amount's own scale rather than forcing two decimals, and `ca.CurrencyAmount()` bridges back to the `float64` form.
+The exact counterpart of `CurrencyAmount`, pairing a `Currency` with a `DecimalAmount`. Same shape — constructors `NewCurrencyDecimalAmount`, `CurrencyDecimalAmountUSD/EUR/CHF/GBP/JPY`, and `ParseCurrencyDecimalAmount(str, decimals...)` — plus `FormatSep`, `String`, `GoString`, `ScanString`, `sql.Scanner`/`driver.Valuer`. Formatting uses the amount's own scale rather than forcing two decimals, and `ca.CurrencyAmount()` bridges back to the `float64` form.
 
 ## Rate
 

--- a/money/amount.go
+++ b/money/amount.go
@@ -93,6 +93,14 @@ func (a Amount) Cents() int64 {
 	return int64(math.Round(float64(a) * 100))
 }
 
+// DecimalAmount converts the float64 Amount to an exact fixed-point
+// DecimalAmount rounded to the given scale with the given rounding mode.
+// It panics if the Amount is NaN, infinite, or does not fit the DecimalAmount
+// range. See DecimalAmountFromAmount for an error-returning variant.
+func (a Amount) DecimalAmount(scale int, rounding RoundingMode) DecimalAmount {
+	return mustDecimalFromFloat(float64(a), scale, rounding)
+}
+
 // WithinOneCent returns true if a and b are equal
 // within a one cent tolerance.
 func (a Amount) WithinOneCent(b Amount) bool {

--- a/money/amount.go
+++ b/money/amount.go
@@ -95,8 +95,10 @@ func (a Amount) Cents() int64 {
 
 // DecimalAmount converts the float64 Amount to an exact fixed-point
 // DecimalAmount rounded to the given scale with the given rounding mode.
-// It panics if the Amount is NaN, infinite, or does not fit the DecimalAmount
-// range. See DecimalAmountFromAmount for an error-returning variant.
+// A NaN or infinite Amount maps to the corresponding non-finite DecimalAmount
+// and an out-of-range value maps to ±Inf; it panics only if scale is out of
+// range. See DecimalAmountFromAmount for a variant that returns an error
+// instead of panicking on an out-of-range scale.
 func (a Amount) DecimalAmount(scale int, rounding RoundingMode) DecimalAmount {
 	return mustDecimalFromFloat(float64(a), scale, rounding)
 }

--- a/money/amount.go
+++ b/money/amount.go
@@ -97,8 +97,8 @@ func (a Amount) Cents() int64 {
 // DecimalAmount rounded to the given scale with the given rounding mode.
 // A NaN or infinite Amount maps to the corresponding non-finite DecimalAmount
 // and an out-of-range value maps to ±Inf; it panics only if scale is out of
-// range. See DecimalAmountFromAmount for a variant that returns an error
-// instead of panicking on an out-of-range scale.
+// range. See DecimalAmountFrom for a conversion that keeps the full float64
+// precision instead of rounding to a fixed scale.
 func (a Amount) DecimalAmount(scale int, rounding RoundingMode) DecimalAmount {
 	return mustDecimalFromFloat(float64(a), scale, rounding)
 }
@@ -131,7 +131,7 @@ func (a Amount) RoundToDecimals(decimals int) Amount {
 // formatted with a dot as decimal separator.
 // String implements the fmt.Stringer interface.
 func (a Amount) String() string {
-	return a.RoundToCents().Format(0, '.', 2)
+	return a.RoundToCents().FormatSep(0, '.', 2)
 
 	// neg := a < 0
 	// s := strconv.FormatInt(a.Abs().Cents(), 10)
@@ -201,7 +201,7 @@ func (ptr *Amount) AmountOr(defaultVal Amount) Amount {
 	return *ptr
 }
 
-// Format formats the Amount similar to strconv.FormatFloat with the 'f' format option,
+// FormatSep formats the Amount similar to strconv.FormatFloat with the 'f' format option,
 // but with decimalSep as decimal separator instead of a point
 // and optional grouping of the integer part.
 // Valid values for decimalSep are '.' and ','.
@@ -213,7 +213,7 @@ func (ptr *Amount) AmountOr(defaultVal Amount) Amount {
 // Note that the last digit is not rounded!
 // The special precision -1 uses the smallest number of digits
 // necessary such that ParseFloat will return f exactly.
-func (a Amount) Format(thousandsSep, decimalSep rune, precision int) string {
+func (a Amount) FormatSep(thousandsSep, decimalSep rune, precision int) string {
 	return float.Format(float64(a), thousandsSep, decimalSep, precision, true)
 }
 

--- a/money/amountparser.go
+++ b/money/amountparser.go
@@ -32,5 +32,5 @@ func (p *AmountParser) Parse(str string, langHints ...language.Code) (normalized
 			}
 		}
 	}
-	return amount.Format(0, '.', decimals), nil
+	return amount.FormatSep(0, '.', decimals), nil
 }

--- a/money/currencyamount.go
+++ b/money/currencyamount.go
@@ -79,14 +79,14 @@ func ParseCurrencyAmount(str string, acceptedDecimals ...int) (result CurrencyAm
 
 // String implements the fmt.Stringer interface.
 func (ca CurrencyAmount) String() string {
-	return ca.Format(true, 0, '.', 2)
+	return ca.FormatSep(true, 0, '.', 2)
 }
 
-// Format formats the CurrencyAmount using the given separators and decimal precision.
+// FormatSep formats the CurrencyAmount using the given separators and decimal precision.
 // If currencyFirst is true the currency code is placed before the amount,
-// otherwise it is placed after. See Amount.Format for details about the separator and precision arguments.
-func (ca CurrencyAmount) Format(currencyFirst bool, thousandsSep, decimalSep rune, precision int) string {
-	amountStr := ca.Amount.Format(thousandsSep, decimalSep, precision)
+// otherwise it is placed after. See Amount.FormatSep for details about the separator and precision arguments.
+func (ca CurrencyAmount) FormatSep(currencyFirst bool, thousandsSep, decimalSep rune, precision int) string {
+	amountStr := ca.Amount.FormatSep(thousandsSep, decimalSep, precision)
 	if ca.Currency == "" {
 		return amountStr
 	}

--- a/money/currencyamountparser.go
+++ b/money/currencyamountparser.go
@@ -32,5 +32,5 @@ func (p *CurrencyAmountParser) Parse(str string, langHints ...language.Code) (no
 			}
 		}
 	}
-	return amount.Format(true, 0, '.', decimals), nil
+	return amount.FormatSep(true, 0, '.', decimals), nil
 }

--- a/money/currencydecimalamount.go
+++ b/money/currencydecimalamount.go
@@ -126,12 +126,15 @@ func (ca CurrencyDecimalAmount) CurrencyAmount() CurrencyAmount {
 }
 
 // ScanString tries to parse and assign the passed source string as value of the
-// implementing type. Because a DecimalAmount is always exact and finite, the
-// validate flag has no additional effect.
+// implementing type. If validate is true, a non-finite amount (NaN or ±Inf) is
+// rejected.
 func (ca *CurrencyDecimalAmount) ScanString(source string, validate bool) error {
 	parsed, err := ParseCurrencyDecimalAmount(source)
 	if err != nil {
 		return err
+	}
+	if validate && !parsed.Amount.Valid() {
+		return fmt.Errorf("invalid money.CurrencyDecimalAmount: %q", source)
 	}
 	*ca = parsed
 	return nil

--- a/money/currencydecimalamount.go
+++ b/money/currencydecimalamount.go
@@ -4,7 +4,6 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"fmt"
-	"strconv"
 	"strings"
 
 	"github.com/domonda/go-types/strutil"
@@ -148,7 +147,7 @@ func (ca *CurrencyDecimalAmount) Scan(value any) (err error) {
 	case []byte:
 		parsed, err = ParseCurrencyDecimalAmount(string(x))
 	case float64:
-		parsed.Amount, err = ParseDecimalAmount(strconv.FormatFloat(x, 'f', -1, 64))
+		err = parsed.Amount.Scan(x)
 	default:
 		return fmt.Errorf("can't scan SQL value of type %T as money.CurrencyDecimalAmount", value)
 	}

--- a/money/currencydecimalamount.go
+++ b/money/currencydecimalamount.go
@@ -1,0 +1,166 @@
+package money
+
+import (
+	"database/sql"
+	"database/sql/driver"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/domonda/go-types/strutil"
+)
+
+// Implemented interfaces
+var (
+	_ fmt.Stringer   = CurrencyDecimalAmount{}
+	_ fmt.GoStringer = CurrencyDecimalAmount{}
+	_ driver.Valuer  = CurrencyDecimalAmount{}
+	_ sql.Scanner    = (*CurrencyDecimalAmount)(nil)
+)
+
+// CurrencyDecimalAmount combines a Currency code with an exact fixed-point
+// DecimalAmount. It is the exact counterpart of CurrencyAmount, which pairs a
+// Currency with a float64-based Amount.
+type CurrencyDecimalAmount struct {
+	Currency Currency
+	Amount   DecimalAmount
+}
+
+// NewCurrencyDecimalAmount returns a CurrencyDecimalAmount with the given
+// currency and amount.
+func NewCurrencyDecimalAmount(currency Currency, amount DecimalAmount) CurrencyDecimalAmount {
+	return CurrencyDecimalAmount{Currency: currency, Amount: amount}
+}
+
+// CurrencyDecimalAmountUSD returns a CurrencyDecimalAmount with the amount in USD (US Dollar).
+func CurrencyDecimalAmountUSD(amount DecimalAmount) CurrencyDecimalAmount {
+	return CurrencyDecimalAmount{Currency: USD, Amount: amount}
+}
+
+// CurrencyDecimalAmountEUR returns a CurrencyDecimalAmount with the amount in EUR (Euro).
+func CurrencyDecimalAmountEUR(amount DecimalAmount) CurrencyDecimalAmount {
+	return CurrencyDecimalAmount{Currency: EUR, Amount: amount}
+}
+
+// CurrencyDecimalAmountCHF returns a CurrencyDecimalAmount with the amount in CHF (Swiss Franc).
+func CurrencyDecimalAmountCHF(amount DecimalAmount) CurrencyDecimalAmount {
+	return CurrencyDecimalAmount{Currency: CHF, Amount: amount}
+}
+
+// CurrencyDecimalAmountGBP returns a CurrencyDecimalAmount with the amount in GBP (British Pound).
+func CurrencyDecimalAmountGBP(amount DecimalAmount) CurrencyDecimalAmount {
+	return CurrencyDecimalAmount{Currency: GBP, Amount: amount}
+}
+
+// CurrencyDecimalAmountJPY returns a CurrencyDecimalAmount with the amount in JPY (Japanese Yen).
+func CurrencyDecimalAmountJPY(amount DecimalAmount) CurrencyDecimalAmount {
+	return CurrencyDecimalAmount{Currency: JPY, Amount: amount}
+}
+
+// ParseCurrencyDecimalAmount parses a currency and an exact amount from str with
+// acceptedDecimals. If acceptedDecimals is empty, then any number of decimal
+// places up to MaxDecimalAmountScale is accepted. The amount is parsed exactly
+// via ParseDecimalAmount.
+func ParseCurrencyDecimalAmount(str string, acceptedDecimals ...int) (result CurrencyDecimalAmount, err error) {
+	str = strutil.TrimSpace(str)
+
+	// Find first separator between currency and amount
+	if pos := strings.IndexAny(str, " .,'-+0123456789"); pos != -1 {
+		// Try parsing string until separator as currency
+		result.Currency, err = NormalizeCurrency(str[:pos])
+		if err == nil {
+			// Set str to remaining amount part
+			str = strings.TrimLeft(str[pos:], " ")
+		} else {
+			// If currency was not at string start, try from end
+			pos = strings.LastIndexAny(str, " .,'-+0123456789")
+			if pos != -1 && len(str)-pos > 0 {
+				result.Currency, err = NormalizeCurrency(str[pos+1:])
+				if err == nil {
+					// Set str to remaining amount part
+					str = strings.TrimRight(str[:pos+1], " ")
+				}
+			}
+		}
+	}
+
+	result.Amount, err = ParseDecimalAmount(str, acceptedDecimals...)
+	if err != nil {
+		return CurrencyDecimalAmount{}, err
+	}
+
+	return result, nil
+}
+
+// String implements the fmt.Stringer interface, placing the currency before the
+// amount and using the amount's own scale (unlike CurrencyAmount.String, which
+// forces two decimal places).
+func (ca CurrencyDecimalAmount) String() string {
+	return ca.Format(true, 0, '.')
+}
+
+// Format formats the CurrencyDecimalAmount using the given separators. If
+// currencyFirst is true the currency code is placed before the amount,
+// otherwise it is placed after. The number of decimal places is the amount's
+// own Scale; see DecimalAmount.FormatSep for the separator arguments.
+func (ca CurrencyDecimalAmount) Format(currencyFirst bool, thousandsSep, decimalSep rune) string {
+	amountStr := ca.Amount.FormatSep(thousandsSep, decimalSep)
+	if ca.Currency == "" {
+		return amountStr
+	}
+	if currencyFirst {
+		return string(ca.Currency) + " " + amountStr
+	}
+	return amountStr + " " + string(ca.Currency)
+}
+
+// GoString returns a Go syntax representation of the CurrencyDecimalAmount for
+// debugging. GoString implements the fmt.GoStringer interface.
+func (ca CurrencyDecimalAmount) GoString() string {
+	return fmt.Sprintf("{Currency: %#v, Amount: %#v}", ca.Currency, ca.Amount)
+}
+
+// CurrencyAmount returns the value as a float64-based CurrencyAmount,
+// which may lose precision. See DecimalAmount.Amount.
+func (ca CurrencyDecimalAmount) CurrencyAmount() CurrencyAmount {
+	return CurrencyAmount{Currency: ca.Currency, Amount: ca.Amount.Amount()}
+}
+
+// ScanString tries to parse and assign the passed source string as value of the
+// implementing type. Because a DecimalAmount is always exact and finite, the
+// validate flag has no additional effect.
+func (ca *CurrencyDecimalAmount) ScanString(source string, validate bool) error {
+	parsed, err := ParseCurrencyDecimalAmount(source)
+	if err != nil {
+		return err
+	}
+	*ca = parsed
+	return nil
+}
+
+// Scan implements the database/sql.Scanner interface using
+// ParseCurrencyDecimalAmount.
+func (ca *CurrencyDecimalAmount) Scan(value any) (err error) {
+	var parsed CurrencyDecimalAmount
+	switch x := value.(type) {
+	case string:
+		parsed, err = ParseCurrencyDecimalAmount(x)
+	case []byte:
+		parsed, err = ParseCurrencyDecimalAmount(string(x))
+	case float64:
+		parsed.Amount, err = ParseDecimalAmount(strconv.FormatFloat(x, 'f', -1, 64))
+	default:
+		return fmt.Errorf("can't scan SQL value of type %T as money.CurrencyDecimalAmount", value)
+	}
+	if err != nil {
+		return err
+	}
+	*ca = parsed
+	return nil
+}
+
+// Value implements the database/sql/driver.Valuer interface by returning the
+// result of the String method.
+func (ca CurrencyDecimalAmount) Value() (driver.Value, error) {
+	return ca.String(), nil
+}

--- a/money/currencydecimalamount.go
+++ b/money/currencydecimalamount.go
@@ -95,14 +95,14 @@ func ParseCurrencyDecimalAmount(str string, acceptedDecimals ...int) (result Cur
 // amount and using the amount's own scale (unlike CurrencyAmount.String, which
 // forces two decimal places).
 func (ca CurrencyDecimalAmount) String() string {
-	return ca.Format(true, 0, '.')
+	return ca.FormatSep(true, 0, '.')
 }
 
-// Format formats the CurrencyDecimalAmount using the given separators. If
+// FormatSep formats the CurrencyDecimalAmount using the given separators. If
 // currencyFirst is true the currency code is placed before the amount,
 // otherwise it is placed after. The number of decimal places is the amount's
 // own Scale; see DecimalAmount.FormatSep for the separator arguments.
-func (ca CurrencyDecimalAmount) Format(currencyFirst bool, thousandsSep, decimalSep rune) string {
+func (ca CurrencyDecimalAmount) FormatSep(currencyFirst bool, thousandsSep, decimalSep rune) string {
 	amountStr := ca.Amount.FormatSep(thousandsSep, decimalSep)
 	if ca.Currency == "" {
 		return amountStr

--- a/money/currencydecimalamount_test.go
+++ b/money/currencydecimalamount_test.go
@@ -1,0 +1,125 @@
+package money
+
+import (
+	"database/sql/driver"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCurrencyDecimalAmount_String(t *testing.T) {
+	ca := CurrencyDecimalAmountEUR(NewDecimalAmount(123456, 2))
+	assert.Equal(t, "EUR 1234.56", ca.String())
+
+	// The amount's own scale is preserved, unlike CurrencyAmount which forces 2.
+	assert.Equal(t, "EUR 1234.5678", CurrencyDecimalAmountEUR(NewDecimalAmount(12345678, 4)).String())
+	assert.Equal(t, "JPY 1000", CurrencyDecimalAmountJPY(NewDecimalAmount(1000, 0)).String())
+
+	// Empty currency omits the code.
+	assert.Equal(t, "1234.56", NewCurrencyDecimalAmount("", NewDecimalAmount(123456, 2)).String())
+}
+
+func TestCurrencyDecimalAmount_constructors(t *testing.T) {
+	amount := NewDecimalAmount(100, 2)
+	assert.Equal(t, Currency("USD"), CurrencyDecimalAmountUSD(amount).Currency)
+	assert.Equal(t, Currency("EUR"), CurrencyDecimalAmountEUR(amount).Currency)
+	assert.Equal(t, Currency("CHF"), CurrencyDecimalAmountCHF(amount).Currency)
+	assert.Equal(t, Currency("GBP"), CurrencyDecimalAmountGBP(amount).Currency)
+	assert.Equal(t, Currency("JPY"), CurrencyDecimalAmountJPY(amount).Currency)
+	assert.Equal(t, amount, NewCurrencyDecimalAmount(EUR, amount).Amount)
+}
+
+func TestCurrencyDecimalAmount_Format(t *testing.T) {
+	ca := CurrencyDecimalAmountEUR(NewDecimalAmount(123456789, 2)) // 1234567.89
+	assert.Equal(t, "EUR 1,234,567.89", ca.Format(true, ',', '.'))
+	assert.Equal(t, "1.234.567,89 EUR", ca.Format(false, '.', ','))
+}
+
+func TestParseCurrencyDecimalAmount(t *testing.T) {
+	cases := []struct {
+		str      string
+		currency Currency
+		amount   string
+	}{
+		{"EUR 1234.56", EUR, "1234.56"},
+		{"1234.56 EUR", EUR, "1234.56"},
+		{"USD 1,234.56", USD, "1234.56"},
+		{"1.234,56 EUR", EUR, "1234.56"},
+		{"CHF 1'234.56", CHF, "1234.56"},
+		{"-99.99 USD", USD, "-99.99"},
+		// Exactness preserved through the currency+amount parse.
+		{"EUR 99999999999999.99", EUR, "99999999999999.99"},
+	}
+	for _, c := range cases {
+		ca, err := ParseCurrencyDecimalAmount(c.str)
+		require.NoError(t, err, "ParseCurrencyDecimalAmount(%q)", c.str)
+		assert.Equal(t, c.currency, ca.Currency, "currency of %q", c.str)
+		assert.Equal(t, c.amount, ca.Amount.String(), "amount of %q", c.str)
+	}
+}
+
+func TestParseCurrencyDecimalAmount_acceptedDecimals(t *testing.T) {
+	_, err := ParseCurrencyDecimalAmount("EUR 1.234", 0, 2)
+	assert.Error(t, err)
+
+	ca, err := ParseCurrencyDecimalAmount("EUR 1.23", 0, 2)
+	require.NoError(t, err)
+	assert.Equal(t, "1.23", ca.Amount.String())
+}
+
+func TestCurrencyDecimalAmount_GoString(t *testing.T) {
+	ca := CurrencyDecimalAmountEUR(NewDecimalAmount(123456, 2))
+	assert.Equal(t, "{Currency: \"EUR\", Amount: money.NewDecimalAmount(123456, 2)}", ca.GoString())
+	assert.Equal(t, "{Currency: \"EUR\", Amount: money.NewDecimalAmount(123456, 2)}", fmt.Sprintf("%#v", ca))
+}
+
+func TestCurrencyDecimalAmount_SQL(t *testing.T) {
+	ca := CurrencyDecimalAmountEUR(NewDecimalAmount(123456, 2))
+	v, err := ca.Value()
+	require.NoError(t, err)
+	assert.Equal(t, "EUR 1234.56", v)
+	assert.IsType(t, driver.Value(""), v)
+
+	var scanned CurrencyDecimalAmount
+	require.NoError(t, scanned.Scan("EUR 1234.56"))
+	assert.Equal(t, ca, scanned)
+
+	require.NoError(t, scanned.Scan([]byte("USD 1.234,56")))
+	assert.Equal(t, Currency("USD"), scanned.Currency)
+	assert.Equal(t, "1234.56", scanned.Amount.String())
+
+	// Bare float64 from the driver has no currency.
+	require.NoError(t, scanned.Scan(float64(12.5)))
+	assert.Equal(t, Currency(""), scanned.Currency)
+	assert.Equal(t, "12.5", scanned.Amount.String())
+
+	assert.Error(t, scanned.Scan(true))
+}
+
+func TestCurrencyDecimalAmount_JSON(t *testing.T) {
+	ca := CurrencyDecimalAmountEUR(NewDecimalAmount(99999, 2))
+	data, err := json.Marshal(ca)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"Currency":"EUR","Amount":999.99}`, string(data))
+
+	var got CurrencyDecimalAmount
+	require.NoError(t, json.Unmarshal(data, &got))
+	assert.Equal(t, ca, got)
+}
+
+func TestCurrencyDecimalAmount_CurrencyAmount(t *testing.T) {
+	ca := CurrencyDecimalAmountEUR(NewDecimalAmount(123456, 2))
+	fa := ca.CurrencyAmount()
+	assert.Equal(t, Currency("EUR"), fa.Currency)
+	assert.InDelta(t, 1234.56, float64(fa.Amount), 1e-9)
+}
+
+func TestCurrencyDecimalAmount_ScanString(t *testing.T) {
+	var ca CurrencyDecimalAmount
+	require.NoError(t, ca.ScanString("EUR 1.234,56", true))
+	assert.Equal(t, Currency("EUR"), ca.Currency)
+	assert.Equal(t, "1234.56", ca.Amount.String())
+}

--- a/money/currencydecimalamount_test.go
+++ b/money/currencydecimalamount_test.go
@@ -34,8 +34,8 @@ func TestCurrencyDecimalAmount_constructors(t *testing.T) {
 
 func TestCurrencyDecimalAmount_Format(t *testing.T) {
 	ca := CurrencyDecimalAmountEUR(NewDecimalAmount(123456789, 2)) // 1234567.89
-	assert.Equal(t, "EUR 1,234,567.89", ca.Format(true, ',', '.'))
-	assert.Equal(t, "1.234.567,89 EUR", ca.Format(false, '.', ','))
+	assert.Equal(t, "EUR 1,234,567.89", ca.FormatSep(true, ',', '.'))
+	assert.Equal(t, "1.234.567,89 EUR", ca.FormatSep(false, '.', ','))
 }
 
 func TestParseCurrencyDecimalAmount(t *testing.T) {

--- a/money/decimalamount.go
+++ b/money/decimalamount.go
@@ -37,8 +37,8 @@ var (
 
 // RoundingMode selects how a value that cannot be represented exactly at the
 // target scale is rounded. It is used by every DecimalAmount operation that may
-// round: RoundToDecimals, RoundToCents, RoundToInt, Mul, Div, MultipliedByRate,
-// DividedByRate, Percentage and the float conversions.
+// round: RoundToDecimals, RoundToCents, RoundToInt, the float conversions, and
+// Mul/Div when the exact result needs more precision than is representable.
 type RoundingMode uint8
 
 const (
@@ -110,6 +110,15 @@ func (m RoundingMode) String() string {
 // The zero value is a valid finite amount of 0 with scale 0.
 type DecimalAmount struct {
 	packed int64
+}
+
+// NullableDecimalAmount is a nullable DecimalAmount whose zero value is NULL.
+type NullableDecimalAmount = nullable.Type[DecimalAmount]
+
+// NullableDecimalAmountFromPtr returns a NullableDecimalAmount from a pointer,
+// using nil as the null value.
+func NullableDecimalAmountFromPtr(ptr *DecimalAmount) NullableDecimalAmount {
+	return nullable.TypeFromPtr(ptr)
 }
 
 const (
@@ -203,10 +212,75 @@ func NewDecimalAmount(coefficient int64, scale int) DecimalAmount {
 	return packDecimalAmount(coefficient, scale)
 }
 
-// DecimalAmountFromInt returns i as a DecimalAmount with scale 0.
-// It panics if i is outside the representable coefficient range.
-func DecimalAmountFromInt(i int64) DecimalAmount {
-	return NewDecimalAmount(i, 0)
+// DecimalAmountConvertible lists the types DecimalAmountFrom converts from:
+// the integer and floating point types and the float64-based Amount and Rate.
+type DecimalAmountConvertible interface {
+	int | int8 | int16 | int32 | int64 |
+		uint | uint8 | uint16 | uint32 | uint64 |
+		float32 | float64 | Amount | Rate
+}
+
+// DecimalAmountFrom returns value as a DecimalAmount without losing any
+// precision of the source type.
+//
+// An integer converts exactly with scale 0. A floating point value (float32,
+// float64, Amount, Rate) converts to the shortest decimal representation that
+// round-trips to the same value, so no float precision is lost; a value whose
+// shortest representation needs more than MaxDecimalAmountScale fractional
+// digits is rounded half away from zero at that scale. NaN and ±Inf map to
+// the corresponding non-finite DecimalAmount, and a value outside the
+// representable range maps to ±Inf.
+func DecimalAmountFrom[T DecimalAmountConvertible](value T) DecimalAmount {
+	switch v := any(value).(type) {
+	case int:
+		return decimalFromInt64(int64(v))
+	case int8:
+		return decimalFromInt64(int64(v))
+	case int16:
+		return decimalFromInt64(int64(v))
+	case int32:
+		return decimalFromInt64(int64(v))
+	case int64:
+		return decimalFromInt64(v)
+	case uint:
+		return decimalFromUint64(uint64(v))
+	case uint8:
+		return decimalFromInt64(int64(v))
+	case uint16:
+		return decimalFromInt64(int64(v))
+	case uint32:
+		return decimalFromInt64(int64(v))
+	case uint64:
+		return decimalFromUint64(v)
+	case float32:
+		return decimalFromFloatShortest(float64(v), 32)
+	case float64:
+		return decimalFromFloatShortest(v, 64)
+	case Amount:
+		return decimalFromFloatShortest(float64(v), 64)
+	case Rate:
+		return decimalFromFloatShortest(float64(v), 64)
+	default:
+		panic("unreachable: DecimalAmountConvertible covers all cases")
+	}
+}
+
+// decimalFromInt64 returns i at scale 0, or ±Inf if i is outside the
+// representable coefficient range.
+func decimalFromInt64(i int64) DecimalAmount {
+	if i < minDecimalAmountCoefficient || i > maxDecimalAmountCoefficient {
+		return decimalInf(i < 0)
+	}
+	return packDecimalAmount(i, 0)
+}
+
+// decimalFromUint64 returns u at scale 0, or +Inf if u is outside the
+// representable coefficient range.
+func decimalFromUint64(u uint64) DecimalAmount {
+	if u > uint64(maxDecimalAmountCoefficient) {
+		return decimalInf(false)
+	}
+	return packDecimalAmount(int64(u), 0) //#nosec G115 -- u is a bounded coefficient magnitude
 }
 
 // DecimalAmountNaN returns the not-a-number DecimalAmount.
@@ -259,22 +333,6 @@ func (a DecimalAmount) IsInf(sign int) bool {
 	default:
 		return c != 0
 	}
-}
-
-// DecimalAmountFromFloat converts f to a DecimalAmount at the given scale,
-// rounding the exact value of the binary float64 with the given rounding mode.
-// A NaN or infinite f maps to the corresponding non-finite DecimalAmount and an
-// out-of-range value maps to ±Inf; an error is returned only for an out-of-range
-// scale.
-func DecimalAmountFromFloat(f float64, scale int, rounding RoundingMode) (DecimalAmount, error) {
-	return decimalFromFloatRounded(f, scale, rounding)
-}
-
-// DecimalAmountFromAmount converts the float64-based Amount to a DecimalAmount at
-// the given scale using the given rounding mode. It is the inverse of
-// DecimalAmount.Amount and shares the precision caveat of DecimalAmountFromFloat.
-func DecimalAmountFromAmount(amount Amount, scale int, rounding RoundingMode) (DecimalAmount, error) {
-	return decimalFromFloatRounded(float64(amount), scale, rounding)
 }
 
 // ParseDecimalAmount parses an exact fixed-point amount from str using the same
@@ -345,20 +403,6 @@ func ParseDecimalAmount(str string, acceptedDecimals ...int) (DecimalAmount, err
 	return packDecimalAmount(coefficient, decimals), nil
 }
 
-// NullableDecimalAmount is a nullable DecimalAmount whose zero value is NULL.
-type NullableDecimalAmount = nullable.Type[DecimalAmount]
-
-// NullableDecimalAmountFrom returns a non-null NullableDecimalAmount wrapping value.
-func NullableDecimalAmountFrom(value DecimalAmount) NullableDecimalAmount {
-	return nullable.TypeFrom(value)
-}
-
-// NullableDecimalAmountFromPtr returns a NullableDecimalAmount from a pointer,
-// using nil as the null value.
-func NullableDecimalAmountFromPtr(ptr *DecimalAmount) NullableDecimalAmount {
-	return nullable.TypeFromPtr(ptr)
-}
-
 // Coefficient returns the unscaled integer value; the finite amount equals
 // Coefficient × 10^-Scale. It is only meaningful when IsFinite is true.
 func (a DecimalAmount) Coefficient() int64 {
@@ -374,6 +418,11 @@ func (a DecimalAmount) Scale() int {
 // Ptr returns a pointer to a copy of the amount.
 func (a DecimalAmount) Ptr() *DecimalAmount {
 	return &a
+}
+
+// Nullable returns the amount wrapped in a non-null NullableDecimalAmount.
+func (a DecimalAmount) Nullable() NullableDecimalAmount {
+	return nullable.TypeFrom(a)
 }
 
 // Float returns the amount as a float64, which may lose precision.
@@ -551,21 +600,26 @@ func (a DecimalAmount) Add(b DecimalAmount) DecimalAmount {
 		sumHi, sumLo = subU128(bHi, bLo, aHi, aLo)
 		negSum = negB
 	}
-	// Reduce the scale by stripping exact trailing zeros while the magnitude
-	// exceeds the coefficient range; only a genuinely too-large integer part
-	// (indivisible by 10) overflows to ±Inf.
-	for scale > 0 && (sumHi != 0 || sumLo > uint64(maxDecimalAmountCoefficient)) {
-		quoHi, quoLo, rem := div128by64(sumHi, sumLo, 10)
+	return packReduced(sumHi, sumLo, scale, negSum)
+}
+
+// packReduced packs the 128-bit magnitude (hi, lo) at scale, reducing the
+// scale by stripping exact trailing zeros while the magnitude exceeds the
+// coefficient range; only a genuinely too-large integer part (indivisible by
+// 10) overflows to ±Inf. No rounding is performed.
+func packReduced(hi, lo uint64, scale int, negative bool) DecimalAmount {
+	for scale > 0 && (hi != 0 || lo > uint64(maxDecimalAmountCoefficient)) {
+		quoHi, quoLo, rem := div128by64(hi, lo, 10)
 		if rem != 0 {
 			break
 		}
-		sumHi, sumLo, scale = quoHi, quoLo, scale-1
+		hi, lo, scale = quoHi, quoLo, scale-1
 	}
-	if sumHi != 0 || sumLo > uint64(maxDecimalAmountCoefficient) {
-		return decimalInf(negSum)
+	if hi != 0 || lo > uint64(maxDecimalAmountCoefficient) {
+		return decimalInf(negative)
 	}
-	coeff := int64(sumLo) //#nosec G115 -- sumLo is a bounded coefficient magnitude
-	if negSum {
+	coeff := int64(lo) //#nosec G115 -- lo is a bounded coefficient magnitude
+	if negative {
 		coeff = -coeff
 	}
 	return packDecimalAmount(coeff, scale)
@@ -577,14 +631,18 @@ func (a DecimalAmount) Sub(b DecimalAmount) DecimalAmount {
 	return a.Add(b.Neg())
 }
 
-// MulInt returns a multiplied by the integer n, keeping a's scale.
-// Overflow yields ±Inf; a NaN receiver yields NaN and ±Inf × 0 yields NaN.
+// MulInt returns a multiplied by the integer n, keeping a's scale. The scale
+// is reduced only when needed to keep the exact product representable;
+// overflow of the integer part yields ±Inf. A NaN receiver yields NaN and
+// ±Inf × 0 yields NaN.
 func (a DecimalAmount) MulInt(n int) DecimalAmount {
 	return a.MulInt64(int64(n))
 }
 
-// MulInt64 returns a multiplied by the integer n, keeping a's scale.
-// Overflow yields ±Inf; a NaN receiver yields NaN and ±Inf × 0 yields NaN.
+// MulInt64 returns a multiplied by the integer n, keeping a's scale. The scale
+// is reduced only when needed to keep the exact product representable;
+// overflow of the integer part yields ±Inf. A NaN receiver yields NaN and
+// ±Inf × 0 yields NaN.
 func (a DecimalAmount) MulInt64(n int64) DecimalAmount {
 	if !a.IsFinite() {
 		switch {
@@ -596,57 +654,56 @@ func (a DecimalAmount) MulInt64(n int64) DecimalAmount {
 			return decimalInf(a.Signbit() != (n < 0))
 		}
 	}
-	product, over := mulOverflow(a.Coefficient(), n)
-	if over || product < minDecimalAmountCoefficient || product > maxDecimalAmountCoefficient {
-		return decimalInf((a.Coefficient() < 0) != (n < 0))
-	}
-	return packDecimalAmount(product, a.Scale())
+	ca := a.Coefficient()
+	hi, lo := bits.Mul64(abs64(ca), abs64(n))
+	return packReduced(hi, lo, a.Scale(), (ca < 0) != (n < 0))
 }
 
-// MultipliedByRate returns the amount multiplied by the float64 Rate, rounded to
-// the given number of decimal places with the given rounding mode. Because Rate
-// is a float64 the product is computed in floating point, so the result is exact
-// only to the requested scale. A non-finite product yields the corresponding
-// NaN or ±Inf. It panics only if scale is out of range.
-func (a DecimalAmount) MultipliedByRate(rate Rate, scale int, rounding RoundingMode) DecimalAmount {
-	return mustDecimalFromFloat(a.Float()*float64(rate), scale, rounding)
+// MultipliedByRate returns the amount multiplied by the float64 Rate. Because
+// Rate is a float64 the product is computed in floating point; the result is
+// the exact shortest decimal representation of that float64 product, so no
+// further precision is lost. Round to the final precision afterwards, e.g.
+// with RoundToCents. A non-finite product yields the corresponding NaN or ±Inf.
+func (a DecimalAmount) MultipliedByRate(rate Rate) DecimalAmount {
+	return decimalFromFloatShortest(a.Float()*float64(rate), 64)
 }
 
-// DividedByRate returns the amount divided by the float64 Rate, rounded to the
-// given number of decimal places with the given rounding mode. See
+// DividedByRate returns the amount divided by the float64 Rate. See
 // MultipliedByRate for the precision caveat. Division by a zero rate yields
-// ±Inf (or NaN). It panics only if scale is out of range.
-func (a DecimalAmount) DividedByRate(rate Rate, scale int, rounding RoundingMode) DecimalAmount {
-	return mustDecimalFromFloat(a.Float()/float64(rate), scale, rounding)
+// ±Inf (or NaN for 0/0).
+func (a DecimalAmount) DividedByRate(rate Rate) DecimalAmount {
+	return decimalFromFloatShortest(a.Float()/float64(rate), 64)
 }
 
-// Percentage returns the amount multiplied by (percent / 100), rounded to the
-// given number of decimal places with the given rounding mode. See
+// Percentage returns the amount multiplied by (percent / 100). See
 // MultipliedByRate for the precision caveat.
-func (a DecimalAmount) Percentage(percent float64, scale int, rounding RoundingMode) DecimalAmount {
-	return mustDecimalFromFloat(a.Float()*percent/100, scale, rounding)
+func (a DecimalAmount) Percentage(percent float64) DecimalAmount {
+	return decimalFromFloatShortest(a.Float()*percent/100, 64)
 }
 
-// Mul returns a × b rounded to the scale of a using the given rounding mode.
-// The exact product is computed in 128-bit integer arithmetic (no heap
-// allocation), so no intermediate precision is lost before rounding. Overflow
-// yields ±Inf; NaN propagates and ±Inf × 0 yields NaN.
+// Mul returns the exact product a × b, computed in 128-bit integer arithmetic
+// (no heap allocation). The result scale is a.Scale()+b.Scale(), reduced only
+// when needed to keep the result representable: exact trailing zeros are
+// stripped first and only then is the value rounded — once, with the given
+// rounding mode — at the largest scale that still fits. Overflow of the
+// integer part yields ±Inf; NaN propagates and ±Inf × 0 yields NaN.
 func (a DecimalAmount) Mul(b DecimalAmount, rounding RoundingMode) DecimalAmount {
 	if r, ok := mulNonFinite(a, b); ok {
 		return r
 	}
 	ca, cb := a.Coefficient(), b.Coefficient()
 	negative := (ca < 0) != (cb < 0)
-	// Exact product coefficient ca·cb has scale a.Scale()+b.Scale(); dividing
-	// by 10^b.Scale() brings it to the target scale a.Scale().
 	hi, lo := bits.Mul64(abs64(ca), abs64(cb))
-	return decimalDivRound(hi, lo, pow10u(b.Scale()), negative, a.Scale(), rounding)
+	return decimalFitRound(hi, lo, a.Scale()+b.Scale(), negative, rounding)
 }
 
-// Div returns a / b rounded to the scale of a using the given rounding mode.
-// The quotient is computed in 128-bit integer arithmetic (no heap allocation).
-// Division by zero yields ±Inf (or NaN for 0/0), overflow yields ±Inf, and NaN
-// propagates.
+// Div returns a / b, computed in 128-bit integer arithmetic (no heap
+// allocation). A quotient that terminates within MaxDecimalAmountScale decimal
+// places is returned exactly, with trailing zeros stripped down to (at least)
+// the preferred scale a.Scale()-b.Scale(); a non-terminating quotient is
+// rounded once with the given rounding mode at the largest scale whose
+// coefficient is representable. Division by zero yields ±Inf (or NaN for 0/0),
+// overflow of the integer part yields ±Inf, and NaN propagates.
 func (a DecimalAmount) Div(b DecimalAmount, rounding RoundingMode) DecimalAmount {
 	if r, ok := divNonFinite(a, b); ok {
 		return r
@@ -659,9 +716,65 @@ func (a DecimalAmount) Div(b DecimalAmount, rounding RoundingMode) DecimalAmount
 		return decimalInf(ca < 0)
 	}
 	negative := (ca < 0) != (cb < 0)
-	// result_coeff = round( ca·10^b.Scale() / cb ) at scale a.Scale().
-	hi, lo := bits.Mul64(abs64(ca), pow10u(b.Scale()))
-	return decimalDivRound(hi, lo, abs64(cb), negative, a.Scale(), rounding)
+	preferred := max(a.Scale()-b.Scale(), 0)
+	ua, ub := abs64(ca), abs64(cb)
+	// Try scales from the maximum downwards; each candidate rounds the true
+	// quotient exactly once. The coefficient at result scale s is
+	// ca·10^(s+b.Scale()-a.Scale()) / cb; the exponent stays non-negative for
+	// every s down to the preferred scale, where the quotient always fits.
+	for scale := MaxDecimalAmountScale; scale >= 0; scale-- {
+		hi, lo, fits := mulByPow10u128(ua, scale+b.Scale()-a.Scale())
+		if !fits {
+			continue // the quotient cannot fit either, retry one place lower
+		}
+		quoHi, quoLo, rem := div128by64(hi, lo, ub)
+		exact := rem == 0
+		if roundUpMagnitude(rounding, quoLo, rem, ub, negative) {
+			quoLo++
+			if quoLo == 0 {
+				quoHi++
+			}
+		}
+		if quoHi != 0 || quoLo > uint64(maxDecimalAmountCoefficient) {
+			continue // does not fit, retry with one decimal place less
+		}
+		if exact {
+			for scale > preferred && quoLo%10 == 0 {
+				quoLo /= 10
+				scale--
+			}
+		}
+		coeff := int64(quoLo) //#nosec G115 -- quoLo is a bounded coefficient magnitude
+		if negative {
+			coeff = -coeff
+		}
+		return packDecimalAmount(coeff, scale)
+	}
+	// Even the integer part of the quotient overflows the coefficient range.
+	return decimalInf(negative)
+}
+
+// mulByPow10u128 returns u·10^n as a 128-bit magnitude for n in
+// [0, 2·MaxDecimalAmountScale]. fits is false when the product overflows
+// 128 bits, which for coefficient-range inputs implies the quotient derived
+// from it cannot fit the coefficient range either.
+func mulByPow10u128(u uint64, n int) (hi, lo uint64, fits bool) {
+	if n <= MaxDecimalAmountScale {
+		hi, lo = bits.Mul64(u, pow10u(n))
+		return hi, lo, true
+	}
+	hi, lo = bits.Mul64(u, pow10u(MaxDecimalAmountScale))
+	m := pow10u(n - MaxDecimalAmountScale)
+	hiHi, hiLo := bits.Mul64(hi, m)
+	if hiHi != 0 {
+		return 0, 0, false
+	}
+	carry, lo2 := bits.Mul64(lo, m)
+	hi2, overflow := bits.Add64(hiLo, carry, 0)
+	if overflow != 0 {
+		return 0, 0, false
+	}
+	return hi2, lo2, true
 }
 
 // RoundToDecimals returns the amount rounded to the given number of decimal
@@ -955,15 +1068,7 @@ func (a *DecimalAmount) Scan(value any) error {
 		// Use the shortest exact decimal when it fits; a value needing more
 		// than MaxDecimalAmountScale fractional digits is rounded to that scale
 		// rather than rejected.
-		if parsed, err := ParseDecimalAmount(strconv.FormatFloat(x, 'f', -1, 64)); err == nil {
-			*a = parsed
-			return nil
-		}
-		parsed, err := DecimalAmountFromFloat(x, MaxDecimalAmountScale, RoundHalfAwayFromZero)
-		if err != nil {
-			return err
-		}
-		*a = parsed
+		*a = decimalFromFloatShortest(x, 64)
 		return nil
 	default:
 		return fmt.Errorf("can't scan value of type %T as money.DecimalAmount", value)
@@ -1067,6 +1172,20 @@ func mustDecimalFromFloat(f float64, scale int, rounding RoundingMode) DecimalAm
 		panic(fmt.Sprintf("money.DecimalAmount from float %v: %s", f, err))
 	}
 	return d
+}
+
+// decimalFromFloatShortest converts f to the DecimalAmount given exactly by
+// the shortest decimal representation that round-trips to f at the given
+// bitSize (32 or 64), so no float precision is lost. A value whose shortest
+// representation needs more than MaxDecimalAmountScale fractional digits (or
+// does not fit the coefficient range) is instead converted at
+// MaxDecimalAmountScale, rounding half away from zero (or yielding ±Inf on
+// overflow). NaN and ±Inf map to the corresponding non-finite values.
+func decimalFromFloatShortest(f float64, bitSize int) DecimalAmount {
+	if parsed, err := ParseDecimalAmount(strconv.FormatFloat(f, 'f', -1, bitSize)); err == nil {
+		return parsed
+	}
+	return mustDecimalFromFloat(f, MaxDecimalAmountScale, RoundHalfAwayFromZero)
 }
 
 // decimalDigits splits abs(coeff) into integer and fractional digit strings for
@@ -1176,8 +1295,9 @@ func writeStr(f fmt.State, s string) {
 	_, _ = io.WriteString(f, s) //#nosec G104 -- writing to a fmt.State cannot fail meaningfully
 }
 
-// abs64 returns the magnitude of x as an unsigned integer. It is safe for every
-// value in the coefficient range, which never reaches math.MinInt64.
+// abs64 returns the magnitude of x as an unsigned integer. It is correct for
+// every int64 including math.MinInt64, whose negation wraps to itself and
+// converts to the right magnitude 2^63.
 func abs64(x int64) uint64 {
 	if x < 0 {
 		return uint64(-x)
@@ -1229,26 +1349,48 @@ func cmpUint128(aHi, aLo, bHi, bLo uint64) int {
 	}
 }
 
-// decimalDivRound divides the 128-bit magnitude (numHi, numLo) by divisor,
-// rounds the quotient to an integer coefficient with the given rounding mode and
-// sign, and packs it at scale. It returns ±Inf if the result does not fit the
-// coefficient range. divisor must be non-zero.
-func decimalDivRound(numHi, numLo, divisor uint64, negative bool, scale int, rounding RoundingMode) DecimalAmount {
-	quoHi, quoLo, rem := div128by64(numHi, numLo, divisor)
-	if roundUpMagnitude(rounding, quoLo, rem, divisor, negative) {
-		quoLo++
-		if quoLo == 0 {
-			quoHi++
+// decimalFitRound packs the exact 128-bit magnitude (hi, lo) at scale,
+// reducing the scale only as needed to make the value representable: exact
+// trailing zeros are stripped first, and a value that still needs more
+// precision than representable is rounded — once, against the original
+// magnitude — with the given rounding mode at the largest scale that fits.
+// ±Inf is returned only when the integer part overflows.
+func decimalFitRound(hi, lo uint64, scale int, negative bool, rounding RoundingMode) DecimalAmount {
+	// Strip exact trailing zeros while the value does not fit.
+	for scale > 0 && (scale > MaxDecimalAmountScale || hi != 0 || lo > uint64(maxDecimalAmountCoefficient)) {
+		quoHi, quoLo, rem := div128by64(hi, lo, 10)
+		if rem != 0 {
+			break
+		}
+		hi, lo, scale = quoHi, quoLo, scale-1
+	}
+	if scale <= MaxDecimalAmountScale && hi == 0 && lo <= uint64(maxDecimalAmountCoefficient) {
+		coeff := int64(lo) //#nosec G115 -- lo is a bounded coefficient magnitude
+		if negative {
+			coeff = -coeff
+		}
+		return packDecimalAmount(coeff, scale)
+	}
+	// Rounded reduction: divide the remaining magnitude by 10^drop for the
+	// smallest drop that fits, so the value is rounded exactly once.
+	for drop := max(1, scale-MaxDecimalAmountScale); drop <= scale && drop <= MaxDecimalAmountScale; drop++ {
+		divisor := pow10u(drop)
+		quoHi, quoLo, rem := div128by64(hi, lo, divisor)
+		if roundUpMagnitude(rounding, quoLo, rem, divisor, negative) {
+			quoLo++
+			if quoLo == 0 {
+				quoHi++
+			}
+		}
+		if quoHi == 0 && quoLo <= uint64(maxDecimalAmountCoefficient) {
+			coeff := int64(quoLo) //#nosec G115 -- quoLo is a bounded coefficient magnitude
+			if negative {
+				coeff = -coeff
+			}
+			return packDecimalAmount(coeff, scale-drop)
 		}
 	}
-	if quoHi != 0 || quoLo > uint64(maxDecimalAmountCoefficient) {
-		return decimalInf(negative)
-	}
-	coeff := int64(quoLo)
-	if negative {
-		coeff = -coeff
-	}
-	return packDecimalAmount(coeff, scale)
+	return decimalInf(negative)
 }
 
 // addNonFinite applies the non-finite rules of Add/Sub. It returns (result,

--- a/money/decimalamount.go
+++ b/money/decimalamount.go
@@ -1,0 +1,1275 @@
+package money
+
+import (
+	"database/sql"
+	"database/sql/driver"
+	"encoding"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math"
+	"math/big"
+	"math/bits"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/invopop/jsonschema"
+
+	"github.com/domonda/go-types/float"
+	"github.com/domonda/go-types/nullable"
+)
+
+// Implemented interfaces
+var (
+	_ fmt.Stringer               = DecimalAmount{}
+	_ fmt.GoStringer             = DecimalAmount{}
+	_ fmt.Formatter              = DecimalAmount{}
+	_ driver.Valuer              = DecimalAmount{}
+	_ sql.Scanner                = (*DecimalAmount)(nil)
+	_ json.Marshaler             = DecimalAmount{}
+	_ json.Unmarshaler           = (*DecimalAmount)(nil)
+	_ encoding.TextMarshaler     = DecimalAmount{}
+	_ encoding.TextUnmarshaler   = (*DecimalAmount)(nil)
+	_ encoding.BinaryMarshaler   = DecimalAmount{}
+	_ encoding.BinaryUnmarshaler = (*DecimalAmount)(nil)
+)
+
+// RoundingMode selects how a value that cannot be represented exactly at the
+// target scale is rounded. It is used by every DecimalAmount operation that may
+// round: RoundToDecimals, RoundToCents, RoundToInt, Mul, Div, MultipliedByRate,
+// DividedByRate, Percentage and the float conversions.
+type RoundingMode uint8
+
+const (
+	// RoundHalfAwayFromZero rounds to nearest, ties away from zero (0.5 → 1,
+	// -0.5 → -1). As the zero value of RoundingMode it is the conventional
+	// default for commercial rounding.
+	RoundHalfAwayFromZero RoundingMode = iota
+	// RoundHalfToEven rounds to nearest, ties to the even neighbor (banker's
+	// rounding: 0.5 → 0, 1.5 → 2).
+	RoundHalfToEven
+	// RoundHalfUp rounds to nearest, ties toward positive infinity.
+	RoundHalfUp
+	// RoundHalfDown rounds to nearest, ties toward negative infinity.
+	RoundHalfDown
+	// RoundDown rounds toward zero (truncates).
+	RoundDown
+	// RoundUp rounds away from zero.
+	RoundUp
+	// RoundFloor rounds toward negative infinity.
+	RoundFloor
+	// RoundCeil rounds toward positive infinity.
+	RoundCeil
+)
+
+// String implements fmt.Stringer.
+func (m RoundingMode) String() string {
+	switch m {
+	case RoundHalfAwayFromZero:
+		return "RoundHalfAwayFromZero"
+	case RoundHalfToEven:
+		return "RoundHalfToEven"
+	case RoundHalfUp:
+		return "RoundHalfUp"
+	case RoundHalfDown:
+		return "RoundHalfDown"
+	case RoundDown:
+		return "RoundDown"
+	case RoundUp:
+		return "RoundUp"
+	case RoundFloor:
+		return "RoundFloor"
+	case RoundCeil:
+		return "RoundCeil"
+	default:
+		return fmt.Sprintf("Unknown rounding mode: %d", uint8(m))
+	}
+}
+
+// DecimalAmount is an exact fixed-point monetary amount stored in a single int64.
+//
+// The value equals Coefficient × 10^-Scale. Both are packed into one int64:
+// the low 5 bits hold the scale (number of decimal places, 0..MaxDecimalAmountScale)
+// and the high 59 bits hold the two's-complement signed coefficient
+// (range ±(2^58-1), roughly 18 significant decimal digits).
+//
+// Finite values are exact: unlike Amount, which is a float64, values like 0.10
+// carry no rounding error. The per-value scale is preserved, so 1.50 (scale 2)
+// and 1.5 (scale 1) are distinct representations of the same value; use Equal or
+// Cmp for value comparison rather than the == operator, which compares the
+// packed bits.
+//
+// DecimalAmount also has the non-finite states NaN, +Inf and -Inf, encoded with
+// the otherwise-unused scale value 31. Arithmetic never panics on overflow or
+// division by zero: overflow yields ±Inf, x/0 yields ±Inf (or NaN for 0/0), and
+// NaN propagates like IEEE floating point. Use Valid/IsFinite/IsNaN/IsInf to
+// test, mirroring Amount. (Explicit misuse — an out-of-range scale or decimals
+// argument — still panics.)
+//
+// The zero value is a valid finite amount of 0 with scale 0.
+type DecimalAmount struct {
+	packed int64
+}
+
+const (
+	// MaxDecimalAmountScale is the maximum number of decimal places a
+	// DecimalAmount can represent. It is bounded by the largest power of ten
+	// that fits in an int64 (10^18, used to rescale coefficients) and by the
+	// ~18 significant digits of the 59-bit coefficient. The 5 scale bits could
+	// encode up to 31, but scales above 18 add no usable precision, so raising
+	// this limit later would be a backward-compatible change.
+	MaxDecimalAmountScale = 18
+
+	scaleBits = 5
+	scaleMask = 1<<scaleBits - 1 // low 5 bits
+
+	// nonFiniteScale is the reserved scale value (31, the top of the 5-bit
+	// field) that tags NaN and ±Inf. The coefficient sign then selects the
+	// kind: +1 → +Inf, -1 → -Inf, 0 → NaN.
+	nonFiniteScale = scaleMask
+
+	// The coefficient range is kept symmetric (excluding the extreme -2^58) so
+	// that Neg and Abs never overflow a valid value.
+	maxDecimalAmountCoefficient = 1<<(63-scaleBits) - 1 // 2^58 - 1
+	minDecimalAmountCoefficient = -maxDecimalAmountCoefficient
+)
+
+// decimalPow10[i] == 10^i for i in 0..MaxDecimalAmountScale.
+// 10^18 is the largest power of ten that fits in an int64.
+var decimalPow10 = [MaxDecimalAmountScale + 1]int64{
+	1,
+	10,
+	100,
+	1000,
+	10000,
+	100000,
+	1000000,
+	10000000,
+	100000000,
+	1000000000,
+	10000000000,
+	100000000000,
+	1000000000000,
+	10000000000000,
+	100000000000000,
+	1000000000000000,
+	10000000000000000,
+	100000000000000000,
+	1000000000000000000,
+}
+
+// packDecimalAmount builds a DecimalAmount from a coefficient and an
+// already-validated scale (0..MaxDecimalAmountScale), panicking if the
+// coefficient exceeds the representable 59-bit range.
+func packDecimalAmount(coefficient int64, scale int) DecimalAmount {
+	if coefficient < minDecimalAmountCoefficient || coefficient > maxDecimalAmountCoefficient {
+		panic(fmt.Sprintf("money.DecimalAmount coefficient %d overflows the representable range [%d, %d]", coefficient, minDecimalAmountCoefficient, maxDecimalAmountCoefficient))
+	}
+	return DecimalAmount{packed: coefficient<<scaleBits | int64(scale)}
+}
+
+// NewDecimalAmount returns a DecimalAmount equal to coefficient × 10^-scale.
+// It panics if scale is not in [0, MaxDecimalAmountScale] or if coefficient is
+// outside the representable range of roughly ±2.88×10^17.
+func NewDecimalAmount(coefficient int64, scale int) DecimalAmount {
+	if scale < 0 || scale > MaxDecimalAmountScale {
+		panic(fmt.Sprintf("money.NewDecimalAmount scale %d out of range [0, %d]", scale, MaxDecimalAmountScale))
+	}
+	return packDecimalAmount(coefficient, scale)
+}
+
+// DecimalAmountFromInt returns i as a DecimalAmount with scale 0.
+// It panics if i is outside the representable coefficient range.
+func DecimalAmountFromInt(i int64) DecimalAmount {
+	return NewDecimalAmount(i, 0)
+}
+
+// DecimalAmountNaN returns the not-a-number DecimalAmount.
+func DecimalAmountNaN() DecimalAmount {
+	return DecimalAmount{packed: nonFiniteScale}
+}
+
+// DecimalAmountInf returns positive infinity if sign >= 0, negative infinity
+// otherwise.
+func DecimalAmountInf(sign int) DecimalAmount {
+	return decimalInf(sign < 0)
+}
+
+// decimalInf returns -Inf if negative, +Inf otherwise.
+func decimalInf(negative bool) DecimalAmount {
+	coeff := int64(1)
+	if negative {
+		coeff = -1
+	}
+	return DecimalAmount{packed: coeff<<scaleBits | nonFiniteScale}
+}
+
+// IsFinite reports whether the amount is a finite number (not NaN or ±Inf).
+func (a DecimalAmount) IsFinite() bool {
+	return int(a.packed&scaleMask) <= MaxDecimalAmountScale
+}
+
+// Valid reports whether the amount is finite. It mirrors Amount.Valid.
+func (a DecimalAmount) Valid() bool {
+	return a.IsFinite()
+}
+
+// IsNaN reports whether the amount is the not-a-number value.
+func (a DecimalAmount) IsNaN() bool {
+	return int(a.packed&scaleMask) == nonFiniteScale && a.Coefficient() == 0
+}
+
+// IsInf reports whether the amount is an infinity of the given sign:
+// sign > 0 tests +Inf, sign < 0 tests -Inf, sign == 0 tests either.
+func (a DecimalAmount) IsInf(sign int) bool {
+	if int(a.packed&scaleMask) != nonFiniteScale {
+		return false
+	}
+	c := a.Coefficient()
+	switch {
+	case sign > 0:
+		return c > 0
+	case sign < 0:
+		return c < 0
+	default:
+		return c != 0
+	}
+}
+
+// DecimalAmountFromFloat converts f to a DecimalAmount at the given scale,
+// rounding the exact value of the binary float64 with the given rounding mode.
+// A NaN or infinite f maps to the corresponding non-finite DecimalAmount and an
+// out-of-range value maps to ±Inf; an error is returned only for an out-of-range
+// scale.
+func DecimalAmountFromFloat(f float64, scale int, rounding RoundingMode) (DecimalAmount, error) {
+	return decimalFromFloatRounded(f, scale, rounding)
+}
+
+// DecimalAmountFromAmount converts the float64-based Amount to a DecimalAmount at
+// the given scale using the given rounding mode. It is the inverse of
+// DecimalAmount.Amount and shares the precision caveat of DecimalAmountFromFloat.
+func DecimalAmountFromAmount(amount Amount, scale int, rounding RoundingMode) (DecimalAmount, error) {
+	return decimalFromFloatRounded(float64(amount), scale, rounding)
+}
+
+// ParseDecimalAmount parses an exact fixed-point amount from str using the same
+// locale-aware separator detection as float.ParseDetails, so both "1,234.56"
+// and "1.234,56" parse to 1234.56. Unlike ParseAmount it is exact: the
+// coefficient is taken directly from the digits of str without a float64
+// round-trip, so values like 99999999999999.99 keep their last cent.
+//
+// The tokens "NaN", "Inf"/"+Inf" and "-Inf" parse to the corresponding
+// non-finite values. Scientific notation is rejected. If acceptedDecimals is
+// non-empty, the number of decimal places must be one of the listed values.
+// An error is returned if the value needs more than MaxDecimalAmountScale
+// decimal places or does not fit the coefficient range.
+func ParseDecimalAmount(str string, acceptedDecimals ...int) (DecimalAmount, error) {
+	// The long "Infinity" spellings are not recognized by float.ParseDetails but
+	// are the PostgreSQL numeric literals emitted by Value.
+	switch strings.TrimSpace(str) {
+	case "Infinity", "+Infinity":
+		return decimalInf(false), nil
+	case "-Infinity":
+		return decimalInf(true), nil
+	}
+	f, _, _, decimals, err := float.ParseDetails(str)
+	if err != nil {
+		return DecimalAmount{}, err
+	}
+	if math.IsNaN(f) {
+		return DecimalAmountNaN(), nil
+	}
+	if math.IsInf(f, 0) {
+		return decimalInf(math.Signbit(f)), nil
+	}
+	if strings.ContainsAny(str, "eE") {
+		return DecimalAmount{}, fmt.Errorf("scientific notation is not supported for money.DecimalAmount: %q", str)
+	}
+	if decimals > MaxDecimalAmountScale {
+		return DecimalAmount{}, fmt.Errorf("money.DecimalAmount supports at most %d decimal places but %q has %d", MaxDecimalAmountScale, str, decimals)
+	}
+	if len(acceptedDecimals) > 0 && !slices.Contains(acceptedDecimals, decimals) {
+		return DecimalAmount{}, fmt.Errorf("parsing %q returned %d decimals which is not in the accepted list %v", str, decimals, acceptedDecimals)
+	}
+	// The coefficient is exactly the sequence of all digit runes of str:
+	// float.ParseDetails only accepts digits, sign, separators and the
+	// exponent runes 'eE' (rejected above). Separators carry no digits, so
+	// concatenating every digit reconstructs the coefficient, and decimals
+	// (from ParseDetails) is the matching scale.
+	var b strings.Builder
+	b.Grow(len(str))
+	for _, r := range str {
+		if r >= '0' && r <= '9' {
+			b.WriteByte(byte(r))
+		}
+	}
+	coefficient, err := strconv.ParseInt(b.String(), 10, 64)
+	if err != nil {
+		return DecimalAmount{}, fmt.Errorf("money.DecimalAmount value %q is too large: %w", str, err)
+	}
+	if strings.ContainsRune(str, '-') {
+		coefficient = -coefficient
+	}
+	if coefficient < minDecimalAmountCoefficient || coefficient > maxDecimalAmountCoefficient {
+		return DecimalAmount{}, fmt.Errorf("money.DecimalAmount value %q does not fit the representable range", str)
+	}
+	return packDecimalAmount(coefficient, decimals), nil
+}
+
+// NullableDecimalAmount is a nullable DecimalAmount whose zero value is NULL.
+type NullableDecimalAmount = nullable.Type[DecimalAmount]
+
+// NullableDecimalAmountFrom returns a non-null NullableDecimalAmount wrapping value.
+func NullableDecimalAmountFrom(value DecimalAmount) NullableDecimalAmount {
+	return nullable.TypeFrom(value)
+}
+
+// NullableDecimalAmountFromPtr returns a NullableDecimalAmount from a pointer,
+// using nil as the null value.
+func NullableDecimalAmountFromPtr(ptr *DecimalAmount) NullableDecimalAmount {
+	return nullable.TypeFromPtr(ptr)
+}
+
+// Coefficient returns the unscaled integer value; the finite amount equals
+// Coefficient × 10^-Scale. It is only meaningful when IsFinite is true.
+func (a DecimalAmount) Coefficient() int64 {
+	return a.packed >> scaleBits // arithmetic shift preserves the sign
+}
+
+// Scale returns the number of decimal places (0..MaxDecimalAmountScale).
+// It is only meaningful when IsFinite is true.
+func (a DecimalAmount) Scale() int {
+	return int(a.packed & scaleMask)
+}
+
+// Ptr returns a pointer to a copy of the amount.
+func (a DecimalAmount) Ptr() *DecimalAmount {
+	return &a
+}
+
+// Float returns the amount as a float64, which may lose precision.
+func (a DecimalAmount) Float() float64 {
+	return float64(a.Coefficient()) / float64(decimalPow10[a.Scale()])
+}
+
+// Amount returns the amount as a float64-based money.Amount,
+// which may lose precision. See Float.
+func (a DecimalAmount) Amount() Amount {
+	return Amount(a.Float())
+}
+
+// Sign returns -1 if the amount is negative, +1 if positive and 0 if zero.
+// -Inf returns -1, +Inf returns +1 and NaN returns 0.
+func (a DecimalAmount) Sign() int {
+	switch c := a.Coefficient(); {
+	case c < 0:
+		return -1
+	case c > 0:
+		return +1
+	default:
+		return 0
+	}
+}
+
+// IsZero returns whether the amount is exactly finite zero.
+func (a DecimalAmount) IsZero() bool {
+	return a.IsFinite() && a.Coefficient() == 0
+}
+
+// Signbit reports whether the amount is negative (including -Inf).
+func (a DecimalAmount) Signbit() bool {
+	return a.Coefficient() < 0
+}
+
+// Abs returns the absolute value of the amount, keeping its scale.
+// Abs(±Inf) is +Inf and Abs(NaN) is NaN.
+func (a DecimalAmount) Abs() DecimalAmount {
+	if !a.IsFinite() {
+		if a.IsNaN() {
+			return a
+		}
+		return decimalInf(false)
+	}
+	if c := a.Coefficient(); c < 0 {
+		return packDecimalAmount(-c, a.Scale())
+	}
+	return a
+}
+
+// Neg returns the amount with its sign inverted, keeping its scale.
+// Neg(±Inf) flips the infinity and Neg(NaN) is NaN.
+func (a DecimalAmount) Neg() DecimalAmount {
+	if !a.IsFinite() {
+		if a.IsNaN() {
+			return a
+		}
+		return decimalInf(!a.Signbit())
+	}
+	return packDecimalAmount(-a.Coefficient(), a.Scale())
+}
+
+// Cmp compares a and b by value, ignoring their scales, and returns
+// -1 if a < b, +1 if a > b and 0 if they are equal, so 1.50 and 1.5 compare as
+// equal. Non-finite values form a total order -Inf < finite < +Inf < NaN; in
+// particular Cmp treats two NaNs as equal (unlike IEEE floating point) so that
+// DecimalAmount values sort deterministically.
+func (a DecimalAmount) Cmp(b DecimalAmount) int {
+	if a.IsFinite() && b.IsFinite() {
+		as, bs := a.Scale(), b.Scale()
+		if as == bs {
+			switch ac, bc := a.Coefficient(), b.Coefficient(); {
+			case ac < bc:
+				return -1
+			case ac > bc:
+				return +1
+			default:
+				return 0
+			}
+		}
+		// Different scales: cross-multiply with big.Int to avoid overflow.
+		// a < b  <=>  a.coeff·10^b.scale < b.coeff·10^a.scale
+		ai := new(big.Int).Mul(big.NewInt(a.Coefficient()), big.NewInt(decimalPow10[bs]))
+		bi := new(big.Int).Mul(big.NewInt(b.Coefficient()), big.NewInt(decimalPow10[as]))
+		return ai.Cmp(bi)
+	}
+	switch ra, rb := a.orderRank(), b.orderRank(); {
+	case ra < rb:
+		return -1
+	case ra > rb:
+		return +1
+	default:
+		return 0
+	}
+}
+
+// orderRank maps a value to its position in the total order used by Cmp when at
+// least one operand is non-finite: -Inf < finite < +Inf < NaN.
+func (a DecimalAmount) orderRank() int {
+	switch {
+	case a.IsNaN():
+		return 2
+	case a.IsInf(1):
+		return 1
+	case a.IsInf(-1):
+		return -1
+	default:
+		return 0
+	}
+}
+
+// Equal reports whether a and b represent the same value, ignoring scale.
+// It differs from the == operator, which compares the packed representation:
+// NewDecimalAmount(150, 2) == NewDecimalAmount(15, 1) is false, while their
+// Equal is true.
+func (a DecimalAmount) Equal(b DecimalAmount) bool {
+	return a.Cmp(b) == 0
+}
+
+// Add returns a + b. The result scale is the larger of the two scales.
+// Overflow yields ±Inf; +Inf + -Inf and any NaN operand yield NaN.
+func (a DecimalAmount) Add(b DecimalAmount) DecimalAmount {
+	if r, ok := addNonFinite(a, b); ok {
+		return r
+	}
+	scale := a.Scale()
+	if bs := b.Scale(); bs > scale {
+		scale = bs
+	}
+	// Aligning to the larger scale only ever increases scale (pads with zeros),
+	// so no rounding happens and the mode is irrelevant. Alignment overflow
+	// means the dominant operand is unrepresentable at the target scale, so the
+	// result is that operand's infinity.
+	ac, aOver := scaleCoefficient(a.Coefficient(), a.Scale(), scale, RoundHalfAwayFromZero)
+	if aOver {
+		return decimalInf(a.Signbit())
+	}
+	bc, bOver := scaleCoefficient(b.Coefficient(), b.Scale(), scale, RoundHalfAwayFromZero)
+	if bOver {
+		return decimalInf(b.Signbit())
+	}
+	sum, over := addOverflow(ac, bc)
+	if over || sum < minDecimalAmountCoefficient || sum > maxDecimalAmountCoefficient {
+		return decimalInf(ac < 0)
+	}
+	return packDecimalAmount(sum, scale)
+}
+
+// Sub returns a - b. The result scale is the larger of the two scales.
+// Overflow yields ±Inf and NaN operands propagate; see Add.
+func (a DecimalAmount) Sub(b DecimalAmount) DecimalAmount {
+	return a.Add(b.Neg())
+}
+
+// MulInt returns a multiplied by the integer n, keeping a's scale.
+// Overflow yields ±Inf; a NaN receiver yields NaN and ±Inf × 0 yields NaN.
+func (a DecimalAmount) MulInt(n int) DecimalAmount {
+	return a.MulInt64(int64(n))
+}
+
+// MulInt64 returns a multiplied by the integer n, keeping a's scale.
+// Overflow yields ±Inf; a NaN receiver yields NaN and ±Inf × 0 yields NaN.
+func (a DecimalAmount) MulInt64(n int64) DecimalAmount {
+	if !a.IsFinite() {
+		switch {
+		case a.IsNaN():
+			return a
+		case n == 0:
+			return DecimalAmountNaN()
+		default:
+			return decimalInf(a.Signbit() != (n < 0))
+		}
+	}
+	product, over := mulOverflow(a.Coefficient(), n)
+	if over || product < minDecimalAmountCoefficient || product > maxDecimalAmountCoefficient {
+		return decimalInf((a.Coefficient() < 0) != (n < 0))
+	}
+	return packDecimalAmount(product, a.Scale())
+}
+
+// MultipliedByRate returns the amount multiplied by the float64 Rate, rounded to
+// the given number of decimal places with the given rounding mode. Because Rate
+// is a float64 the product is computed in floating point, so the result is exact
+// only to the requested scale. A non-finite product yields the corresponding
+// NaN or ±Inf. It panics only if scale is out of range.
+func (a DecimalAmount) MultipliedByRate(rate Rate, scale int, rounding RoundingMode) DecimalAmount {
+	return mustDecimalFromFloat(a.Float()*float64(rate), scale, rounding)
+}
+
+// DividedByRate returns the amount divided by the float64 Rate, rounded to the
+// given number of decimal places with the given rounding mode. See
+// MultipliedByRate for the precision caveat. Division by a zero rate yields
+// ±Inf (or NaN). It panics only if scale is out of range.
+func (a DecimalAmount) DividedByRate(rate Rate, scale int, rounding RoundingMode) DecimalAmount {
+	return mustDecimalFromFloat(a.Float()/float64(rate), scale, rounding)
+}
+
+// Percentage returns the amount multiplied by (percent / 100), rounded to the
+// given number of decimal places with the given rounding mode. See
+// MultipliedByRate for the precision caveat.
+func (a DecimalAmount) Percentage(percent float64, scale int, rounding RoundingMode) DecimalAmount {
+	return mustDecimalFromFloat(a.Float()*percent/100, scale, rounding)
+}
+
+// Mul returns a × b rounded to the scale of a using the given rounding mode.
+// The exact product is computed in 128-bit integer arithmetic (no heap
+// allocation), so no intermediate precision is lost before rounding. Overflow
+// yields ±Inf; NaN propagates and ±Inf × 0 yields NaN.
+func (a DecimalAmount) Mul(b DecimalAmount, rounding RoundingMode) DecimalAmount {
+	if r, ok := mulNonFinite(a, b); ok {
+		return r
+	}
+	ca, cb := a.Coefficient(), b.Coefficient()
+	negative := (ca < 0) != (cb < 0)
+	// Exact product coefficient ca·cb has scale a.Scale()+b.Scale(); dividing
+	// by 10^b.Scale() brings it to the target scale a.Scale().
+	hi, lo := bits.Mul64(abs64(ca), abs64(cb))
+	return decimalDivRound(hi, lo, uint64(decimalPow10[b.Scale()]), negative, a.Scale(), rounding)
+}
+
+// Div returns a / b rounded to the scale of a using the given rounding mode.
+// The quotient is computed in 128-bit integer arithmetic (no heap allocation).
+// Division by zero yields ±Inf (or NaN for 0/0), overflow yields ±Inf, and NaN
+// propagates.
+func (a DecimalAmount) Div(b DecimalAmount, rounding RoundingMode) DecimalAmount {
+	if r, ok := divNonFinite(a, b); ok {
+		return r
+	}
+	ca, cb := a.Coefficient(), b.Coefficient()
+	if cb == 0 {
+		if ca == 0 {
+			return DecimalAmountNaN()
+		}
+		return decimalInf(ca < 0)
+	}
+	negative := (ca < 0) != (cb < 0)
+	// result_coeff = round( ca·10^b.Scale() / cb ) at scale a.Scale().
+	hi, lo := bits.Mul64(abs64(ca), uint64(decimalPow10[b.Scale()]))
+	return decimalDivRound(hi, lo, abs64(cb), negative, a.Scale(), rounding)
+}
+
+// RoundToDecimals returns the amount rounded to the given number of decimal
+// places with the given rounding mode. The result always has scale == decimals;
+// increasing the scale pads with zeros. A non-finite amount is returned
+// unchanged and padding overflow yields ±Inf. It panics if decimals is out of
+// range [0, MaxDecimalAmountScale].
+func (a DecimalAmount) RoundToDecimals(decimals int, rounding RoundingMode) DecimalAmount {
+	if decimals < 0 || decimals > MaxDecimalAmountScale {
+		panic(fmt.Sprintf("money.DecimalAmount.RoundToDecimals decimals %d out of range [0, %d]", decimals, MaxDecimalAmountScale))
+	}
+	if !a.IsFinite() {
+		return a
+	}
+	coeff, over := scaleCoefficient(a.Coefficient(), a.Scale(), decimals, rounding)
+	if over {
+		return decimalInf(a.Signbit())
+	}
+	return packDecimalAmount(coeff, decimals)
+}
+
+// RoundToCents returns the amount rounded to 2 decimal places using the given
+// rounding mode.
+func (a DecimalAmount) RoundToCents(rounding RoundingMode) DecimalAmount {
+	return a.RoundToDecimals(2, rounding)
+}
+
+// RoundToInt returns the amount rounded to an integer (scale 0) using the given
+// rounding mode.
+func (a DecimalAmount) RoundToInt(rounding RoundingMode) DecimalAmount {
+	return a.RoundToDecimals(0, rounding)
+}
+
+// String returns the exact decimal representation of the amount using a dot as
+// decimal separator and no thousands separator, with exactly Scale digits after
+// the point. Non-finite values return "NaN", "Inf" or "-Inf".
+// String implements fmt.Stringer.
+func (a DecimalAmount) String() string {
+	if !a.IsFinite() {
+		return nonFiniteString(a)
+	}
+	intPart, fracPart, neg := a.parts()
+	var b strings.Builder
+	b.Grow(len(intPart) + len(fracPart) + 2)
+	if neg {
+		b.WriteByte('-')
+	}
+	b.WriteString(intPart)
+	if fracPart != "" {
+		b.WriteByte('.')
+		b.WriteString(fracPart)
+	}
+	return b.String()
+}
+
+// nonFiniteString returns the token for a non-finite value. These tokens
+// round-trip through ParseDecimalAmount.
+func nonFiniteString(a DecimalAmount) string {
+	switch {
+	case a.IsNaN():
+		return "NaN"
+	case a.Signbit():
+		return "-Inf"
+	default:
+		return "Inf"
+	}
+}
+
+// GoString returns a Go source representation of the amount for debugging.
+// GoString implements fmt.GoStringer.
+func (a DecimalAmount) GoString() string {
+	switch {
+	case a.IsNaN():
+		return "money.DecimalAmountNaN()"
+	case a.IsInf(1):
+		return "money.DecimalAmountInf(1)"
+	case a.IsInf(-1):
+		return "money.DecimalAmountInf(-1)"
+	default:
+		return fmt.Sprintf("money.NewDecimalAmount(%d, %d)", a.Coefficient(), a.Scale())
+	}
+}
+
+// FormatSep returns the exact decimal representation of the amount with the
+// given decimal separator and optional thousands separator grouping the integer
+// part. A zero thousandsSep disables grouping; a zero decimalSep defaults to
+// '.'. The number of fractional digits is the amount's Scale.
+func (a DecimalAmount) FormatSep(thousandsSep, decimalSep rune) string {
+	if !a.IsFinite() {
+		return nonFiniteString(a)
+	}
+	if decimalSep == 0 {
+		decimalSep = '.'
+	}
+	intPart, fracPart, neg := a.parts()
+	var b strings.Builder
+	if neg {
+		b.WriteByte('-')
+	}
+	writeGrouped(&b, intPart, thousandsSep)
+	if fracPart != "" {
+		b.WriteRune(decimalSep)
+		b.WriteString(fracPart)
+	}
+	return b.String()
+}
+
+// Format implements fmt.Formatter, giving the amount format-string aware output:
+//
+//	%s, %v  exact decimal string (like String)
+//	%#v     Go source representation (like GoString)
+//	%q      double-quoted exact decimal string
+//	%f, %F  fixed-point with the precision as decimal places
+//	        (default: the amount's own Scale)
+//	%d      integer part, rounded to zero decimals
+//
+// The '+' and ' ' flags control the sign of positive values, the '#' flag
+// groups the integer part with ',' thousands separators (for %v, %s, %f and
+// %d), and the width with the '-' and '0' flags controls padding. Formatting
+// never panics.
+func (a DecimalAmount) Format(f fmt.State, verb rune) {
+	if !a.IsFinite() {
+		if verb == 'v' && f.Flag('#') {
+			io.WriteString(f, a.GoString())
+			return
+		}
+		if verb == 'q' {
+			writePadded(f, strconv.Quote(a.String()))
+			return
+		}
+		writePadded(f, a.String())
+		return
+	}
+	switch verb {
+	case 'v':
+		if f.Flag('#') {
+			io.WriteString(f, a.GoString())
+			return
+		}
+		writePadded(f, a.formatBody(f, a.Scale()))
+	case 's':
+		writePadded(f, a.formatBody(f, a.Scale()))
+	case 'q':
+		writePadded(f, strconv.Quote(a.formatBody(f, a.Scale())))
+	case 'f', 'F':
+		prec := a.Scale()
+		if p, ok := f.Precision(); ok {
+			prec = min(p, MaxDecimalAmountScale)
+		}
+		writePadded(f, a.formatBody(f, prec))
+	case 'd':
+		writePadded(f, a.formatBody(f, 0))
+	default:
+		fmt.Fprintf(f, "%%!%c(money.DecimalAmount=%s)", verb, a.String())
+	}
+}
+
+// MarshalJSON implements json.Marshaler, encoding a finite amount as an unquoted
+// JSON number that preserves the exact value and scale, e.g. 1234.56. Non-finite
+// values are encoded as the quoted strings "NaN", "Inf" or "-Inf" (JSON has no
+// number literal for them). UnmarshalJSON accepts a quoted string for any value.
+func (a DecimalAmount) MarshalJSON() ([]byte, error) {
+	if !a.IsFinite() {
+		return []byte(strconv.Quote(a.String())), nil
+	}
+	return []byte(a.String()), nil
+}
+
+// UnmarshalJSON implements json.Unmarshaler and accepts a JSON number, a quoted
+// decimal string, or null. null and "" are decoded as zero.
+func (a *DecimalAmount) UnmarshalJSON(data []byte) error {
+	s := string(data)
+	if s == "null" || s == `""` {
+		*a = DecimalAmount{}
+		return nil
+	}
+	if l := len(s); l >= 2 && s[0] == '"' && s[l-1] == '"' {
+		s = s[1 : l-1]
+	}
+	parsed, err := ParseDecimalAmount(s)
+	if err != nil {
+		return fmt.Errorf("can't unmarshal JSON %s as money.DecimalAmount: %w", data, err)
+	}
+	*a = parsed
+	return nil
+}
+
+// MarshalText implements encoding.TextMarshaler, returning the exact decimal
+// string (like String).
+func (a DecimalAmount) MarshalText() ([]byte, error) {
+	return []byte(a.String()), nil
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler. An empty text is decoded
+// as zero.
+func (a *DecimalAmount) UnmarshalText(text []byte) error {
+	if len(text) == 0 {
+		*a = DecimalAmount{}
+		return nil
+	}
+	parsed, err := ParseDecimalAmount(string(text))
+	if err != nil {
+		return err
+	}
+	*a = parsed
+	return nil
+}
+
+// MarshalBinary implements encoding.BinaryMarshaler, encoding the packed int64
+// as 8 big-endian bytes.
+func (a DecimalAmount) MarshalBinary() ([]byte, error) {
+	buf := make([]byte, 8)
+	binary.BigEndian.PutUint64(buf, uint64(a.packed)) //#nosec G115 -- packed is a bit pattern
+	return buf, nil
+}
+
+// UnmarshalBinary implements encoding.BinaryUnmarshaler, decoding 8 big-endian
+// bytes produced by MarshalBinary.
+func (a *DecimalAmount) UnmarshalBinary(data []byte) error {
+	if len(data) != 8 {
+		return fmt.Errorf("money.DecimalAmount.UnmarshalBinary needs 8 bytes but got %d", len(data))
+	}
+	packed := int64(binary.BigEndian.Uint64(data)) //#nosec G115 -- restoring a bit pattern
+	scale := int(packed & scaleMask)
+	if scale == nonFiniteScale {
+		// Canonicalize the non-finite encoding from its coefficient sign.
+		switch coeff := packed >> scaleBits; {
+		case coeff > 0:
+			*a = decimalInf(false)
+		case coeff < 0:
+			*a = decimalInf(true)
+		default:
+			*a = DecimalAmountNaN()
+		}
+		return nil
+	}
+	if scale > MaxDecimalAmountScale {
+		return fmt.Errorf("money.DecimalAmount.UnmarshalBinary got invalid scale %d", scale)
+	}
+	a.packed = packed
+	return nil
+}
+
+// Value implements the database/sql/driver.Valuer interface, returning the
+// exact decimal string so it can be stored in a SQL numeric/decimal column
+// without precision loss. Non-finite values use the PostgreSQL numeric literals
+// "NaN", "Infinity" and "-Infinity"; Scan and ParseDecimalAmount read them back.
+func (a DecimalAmount) Value() (driver.Value, error) {
+	if !a.IsFinite() {
+		switch {
+		case a.IsNaN():
+			return "NaN", nil
+		case a.Signbit():
+			return "-Infinity", nil
+		default:
+			return "Infinity", nil
+		}
+	}
+	return a.String(), nil
+}
+
+// Scan implements the database/sql.Scanner interface and accepts string,
+// []byte, int64 and float64. A float64 is converted via its shortest exact
+// decimal representation.
+func (a *DecimalAmount) Scan(value any) error {
+	switch x := value.(type) {
+	case string:
+		return a.scanParse(x)
+	case []byte:
+		return a.scanParse(string(x))
+	case int64:
+		if x < minDecimalAmountCoefficient || x > maxDecimalAmountCoefficient {
+			return fmt.Errorf("int64 %d is out of range for money.DecimalAmount", x)
+		}
+		*a = packDecimalAmount(x, 0)
+		return nil
+	case float64:
+		return a.scanParse(strconv.FormatFloat(x, 'f', -1, 64))
+	default:
+		return fmt.Errorf("can't scan value of type %T as money.DecimalAmount", value)
+	}
+}
+
+// ScanString implements the strfmt scanning convention by parsing source as a
+// DecimalAmount. Because a DecimalAmount is always finite and exact, the
+// validate flag has no additional effect.
+func (a *DecimalAmount) ScanString(source string, validate bool) error {
+	return a.scanParse(source)
+}
+
+// JSONSchema returns the JSON Schema for a DecimalAmount as a numeric type,
+// matching the JSON number produced by MarshalJSON.
+func (DecimalAmount) JSONSchema() *jsonschema.Schema {
+	return &jsonschema.Schema{
+		Type:        "number",
+		Title:       "Decimal Amount",
+		Description: "Exact fixed-point monetary amount",
+	}
+}
+
+func (a *DecimalAmount) scanParse(s string) error {
+	parsed, err := ParseDecimalAmount(s)
+	if err != nil {
+		return err
+	}
+	*a = parsed
+	return nil
+}
+
+// parts splits the absolute value into its integer and fractional digit strings
+// (fracPart has exactly Scale digits, or is empty when Scale is 0) and reports
+// whether the amount is negative.
+func (a DecimalAmount) parts() (intPart, fracPart string, neg bool) {
+	return decimalDigits(a.Coefficient(), a.Scale())
+}
+
+// formatBody renders the amount to prec decimal places (rounding half away from
+// zero, padding with zeros when prec exceeds the scale) and applies the sign
+// ('+'/' ') and grouping ('#') flags of f, but not width/padding. It never
+// panics: reducing precision cannot overflow and padding is done with string
+// zeros rather than by rescaling the coefficient.
+func (a DecimalAmount) formatBody(f fmt.State, prec int) string {
+	var intPart, fracPart string
+	var neg bool
+	if scale := a.Scale(); prec >= scale {
+		intPart, fracPart, neg = a.parts()
+		if pad := prec - scale; pad > 0 {
+			fracPart += strings.Repeat("0", pad)
+		}
+	} else {
+		// Display rounding uses half away from zero; a format verb cannot carry
+		// a RoundingMode. Reducing precision never overflows.
+		coeff, _ := scaleCoefficient(a.Coefficient(), scale, prec, RoundHalfAwayFromZero)
+		intPart, fracPart, neg = decimalDigits(coeff, prec)
+	}
+
+	var b strings.Builder
+	switch {
+	case neg:
+		b.WriteByte('-')
+	case f.Flag('+'):
+		b.WriteByte('+')
+	case f.Flag(' '):
+		b.WriteByte(' ')
+	}
+	if f.Flag('#') {
+		writeGrouped(&b, intPart, ',')
+	} else {
+		b.WriteString(intPart)
+	}
+	if fracPart != "" {
+		b.WriteByte('.')
+		b.WriteString(fracPart)
+	}
+	return b.String()
+}
+
+// mustDecimalFromFloat converts f to a DecimalAmount rounded to scale with the
+// given rounding mode. NaN, infinity and overflow yield the corresponding
+// non-finite value; it panics only on an out-of-range scale (a programmer
+// error).
+func mustDecimalFromFloat(f float64, scale int, rounding RoundingMode) DecimalAmount {
+	d, err := decimalFromFloatRounded(f, scale, rounding)
+	if err != nil {
+		panic(fmt.Sprintf("money.DecimalAmount from float %v: %s", f, err))
+	}
+	return d
+}
+
+// decimalDigits splits abs(coeff) into integer and fractional digit strings for
+// the given scale and reports whether coeff is negative.
+func decimalDigits(coeff int64, scale int) (intPart, fracPart string, neg bool) {
+	neg = coeff < 0
+	if neg {
+		coeff = -coeff
+	}
+	digits := strconv.FormatInt(coeff, 10)
+	switch {
+	case scale == 0:
+		return digits, "", neg
+	case len(digits) <= scale:
+		return "0", strings.Repeat("0", scale-len(digits)) + digits, neg
+	default:
+		return digits[:len(digits)-scale], digits[len(digits)-scale:], neg
+	}
+}
+
+// writeGrouped writes the ASCII digit string intPart to b, inserting sep between
+// every group of three digits from the right. A zero sep disables grouping.
+func writeGrouped(b *strings.Builder, intPart string, sep rune) {
+	if sep == 0 {
+		b.WriteString(intPart)
+		return
+	}
+	n := len(intPart)
+	for i := range n {
+		if i > 0 && (n-i)%3 == 0 {
+			b.WriteRune(sep)
+		}
+		b.WriteByte(intPart[i])
+	}
+}
+
+// writePadded writes s to f, applying the width and the '-' and '0' padding
+// flags. s is expected to be ASCII (digits, sign, '.', ',', '"').
+func writePadded(f fmt.State, s string) {
+	width, ok := f.Width()
+	if !ok || len(s) >= width {
+		io.WriteString(f, s)
+		return
+	}
+	pad := strings.Repeat(padByte(f), width-len(s))
+	switch {
+	case f.Flag('-'):
+		io.WriteString(f, s)
+		io.WriteString(f, pad)
+	case f.Flag('0') && len(s) > 0 && (s[0] == '-' || s[0] == '+' || s[0] == ' '):
+		// Zero-pad after the sign so it stays leftmost.
+		io.WriteString(f, s[:1])
+		io.WriteString(f, pad)
+		io.WriteString(f, s[1:])
+	default:
+		io.WriteString(f, pad)
+		io.WriteString(f, s)
+	}
+}
+
+func padByte(f fmt.State) string {
+	if f.Flag('0') && !f.Flag('-') {
+		return "0"
+	}
+	return " "
+}
+
+// mulOverflow multiplies a and b and reports overflow. The first argument must
+// be a value within the representable coefficient range so that the division
+// check can never hit the MinInt64/-1 division trap.
+func mulOverflow(a, b int64) (int64, bool) {
+	if b == 0 {
+		return 0, false
+	}
+	p := a * b
+	if p/b != a {
+		return 0, true
+	}
+	return p, false
+}
+
+// addOverflow adds a and b and reports signed overflow.
+func addOverflow(a, b int64) (int64, bool) {
+	s := a + b
+	if (a > 0 && b > 0 && s < 0) || (a < 0 && b < 0 && s >= 0) {
+		return 0, true
+	}
+	return s, false
+}
+
+// abs64 returns the magnitude of x as an unsigned integer. It is safe for every
+// value in the coefficient range, which never reaches math.MinInt64.
+func abs64(x int64) uint64 {
+	if x < 0 {
+		return uint64(-x)
+	}
+	return uint64(x)
+}
+
+// decimalDivRound divides the 128-bit magnitude (numHi, numLo) by divisor,
+// rounds the quotient to an integer coefficient with the given rounding mode and
+// sign, and packs it at scale. It returns ±Inf if the result does not fit the
+// coefficient range. divisor must be non-zero.
+func decimalDivRound(numHi, numLo, divisor uint64, negative bool, scale int, rounding RoundingMode) DecimalAmount {
+	quoHi, quoLo, rem := div128by64(numHi, numLo, divisor)
+	if roundUpMagnitude(rounding, quoLo, rem, divisor, negative) {
+		quoLo++
+		if quoLo == 0 {
+			quoHi++
+		}
+	}
+	if quoHi != 0 || quoLo > uint64(maxDecimalAmountCoefficient) {
+		return decimalInf(negative)
+	}
+	coeff := int64(quoLo)
+	if negative {
+		coeff = -coeff
+	}
+	return packDecimalAmount(coeff, scale)
+}
+
+// addNonFinite applies the non-finite rules of Add/Sub. It returns (result,
+// true) when at least one operand is non-finite, otherwise (_, false).
+func addNonFinite(a, b DecimalAmount) (DecimalAmount, bool) {
+	if a.IsFinite() && b.IsFinite() {
+		return DecimalAmount{}, false
+	}
+	if a.IsNaN() || b.IsNaN() {
+		return DecimalAmountNaN(), true
+	}
+	// At least one is ±Inf, neither is NaN.
+	if !a.IsFinite() && !b.IsFinite() {
+		if a.Signbit() != b.Signbit() {
+			return DecimalAmountNaN(), true // +Inf + -Inf
+		}
+		return a, true
+	}
+	if !a.IsFinite() {
+		return a, true
+	}
+	return b, true
+}
+
+// mulNonFinite applies the non-finite rules of Mul.
+func mulNonFinite(a, b DecimalAmount) (DecimalAmount, bool) {
+	if a.IsFinite() && b.IsFinite() {
+		return DecimalAmount{}, false
+	}
+	if a.IsNaN() || b.IsNaN() {
+		return DecimalAmountNaN(), true
+	}
+	if a.IsZero() || b.IsZero() { // ±Inf × 0
+		return DecimalAmountNaN(), true
+	}
+	return decimalInf(a.Signbit() != b.Signbit()), true
+}
+
+// divNonFinite applies the non-finite rules of Div. Division by a finite zero is
+// left to the finite path.
+func divNonFinite(a, b DecimalAmount) (DecimalAmount, bool) {
+	if a.IsFinite() && b.IsFinite() {
+		return DecimalAmount{}, false
+	}
+	if a.IsNaN() || b.IsNaN() {
+		return DecimalAmountNaN(), true
+	}
+	if !a.IsFinite() && !b.IsFinite() {
+		return DecimalAmountNaN(), true // Inf / Inf
+	}
+	if !a.IsFinite() { // Inf / finite
+		return decimalInf(a.Signbit() != b.Signbit()), true
+	}
+	// finite / Inf = 0 at the receiver's scale.
+	return packDecimalAmount(0, a.Scale()), true
+}
+
+// div128by64 divides the 128-bit unsigned value (hi, lo) by d (which must be
+// non-zero), returning the 128-bit quotient (quoHi, quoLo) and the 64-bit
+// remainder.
+func div128by64(hi, lo, d uint64) (quoHi, quoLo, rem uint64) {
+	if hi >= d {
+		quoHi, hi = bits.Div64(0, hi, d) // hi/d and hi%d; safe because 0 < d
+	}
+	quoLo, rem = bits.Div64(hi, lo, d) // hi < d now, so no quotient overflow
+	return quoHi, quoLo, rem
+}
+
+// roundUpMagnitude reports whether the truncated quotient magnitude quo (with
+// remainder rem over divisor d and the given sign) should be incremented by one
+// under the rounding mode. rem must be less than d.
+func roundUpMagnitude(mode RoundingMode, quo, rem, d uint64, negative bool) bool {
+	if rem == 0 {
+		return false
+	}
+	// Compare 2·rem to d to locate rem relative to the halfway point.
+	// rem < d ≤ 10^18 < 2^60, so doubling cannot overflow.
+	var halfCmp int
+	switch double := rem * 2; {
+	case double > d:
+		halfCmp = +1
+	case double < d:
+		halfCmp = -1
+	}
+	return roundAwayFromZero(mode, negative, quo&1 == 1, halfCmp)
+}
+
+// roundAwayFromZero is the shared rounding decision for a value truncated toward
+// zero that has a non-zero remainder. quotientOdd is the parity of the truncated
+// magnitude and halfCmp compares the remainder to the halfway point
+// (-1 below, 0 exactly half, +1 above). It reports whether the magnitude should
+// be incremented (i.e. rounded away from zero).
+func roundAwayFromZero(mode RoundingMode, negative, quotientOdd bool, halfCmp int) bool {
+	switch mode {
+	case RoundDown:
+		return false
+	case RoundUp:
+		return true
+	case RoundFloor:
+		return negative // toward -Inf: away from zero only when negative
+	case RoundCeil:
+		return !negative // toward +Inf: away from zero only when positive
+	}
+	// Ties-to-nearest variants.
+	if halfCmp > 0 {
+		return true
+	}
+	if halfCmp < 0 {
+		return false
+	}
+	switch mode {
+	case RoundHalfToEven:
+		return quotientOdd
+	case RoundHalfUp:
+		return !negative
+	case RoundHalfDown:
+		return negative
+	default: // RoundHalfAwayFromZero
+		return true
+	}
+}
+
+// roundBigQuotient reports whether the truncated quotient quo = num/den (with
+// remainder rem, den > 0) should have its magnitude incremented under the
+// rounding mode.
+func roundBigQuotient(mode RoundingMode, quo, rem, den *big.Int, negative bool) bool {
+	if rem.Sign() == 0 {
+		return false
+	}
+	twiceRem := new(big.Int).Lsh(new(big.Int).Abs(rem), 1)
+	return roundAwayFromZero(mode, negative, quo.Bit(0) == 1, twiceRem.Cmp(den))
+}
+
+// decimalFromFloatRounded converts f to a DecimalAmount at the given scale using
+// the exact value of the binary float64 and the given rounding mode. A NaN or
+// infinite f maps to the corresponding non-finite DecimalAmount and an
+// out-of-range value maps to ±Inf. It returns an error only for an out-of-range
+// scale (a programmer error).
+func decimalFromFloatRounded(f float64, scale int, rounding RoundingMode) (DecimalAmount, error) {
+	if scale < 0 || scale > MaxDecimalAmountScale {
+		return DecimalAmount{}, fmt.Errorf("money.DecimalAmount scale %d out of range [0, %d]", scale, MaxDecimalAmountScale)
+	}
+	switch {
+	case math.IsNaN(f):
+		return DecimalAmountNaN(), nil
+	case math.IsInf(f, 0):
+		return decimalInf(math.Signbit(f)), nil
+	}
+	// Exact value of f, scaled by 10^scale, as a rational num/den (den > 0).
+	r := new(big.Rat).SetFloat64(f)
+	r.Mul(r, new(big.Rat).SetInt64(decimalPow10[scale]))
+	num, den := r.Num(), r.Denom()
+	quo := new(big.Int)
+	rem := new(big.Int)
+	quo.QuoRem(num, den, rem) // truncated toward zero
+	if roundBigQuotient(rounding, quo, rem, den, num.Sign() < 0) {
+		if num.Sign() < 0 {
+			quo.Sub(quo, big.NewInt(1))
+		} else {
+			quo.Add(quo, big.NewInt(1))
+		}
+	}
+	if !quo.IsInt64() {
+		return decimalInf(f < 0), nil
+	}
+	coeff := quo.Int64()
+	if coeff < minDecimalAmountCoefficient || coeff > maxDecimalAmountCoefficient {
+		return decimalInf(f < 0), nil
+	}
+	return packDecimalAmount(coeff, scale), nil
+}
+
+// scaleCoefficient returns coeff represented at toScale instead of fromScale and
+// reports overflow. Increasing the scale multiplies by a power of ten and
+// overflows when the coefficient no longer fits the representable range;
+// decreasing the scale rounds according to rounding and never overflows.
+func scaleCoefficient(coeff int64, fromScale, toScale int, rounding RoundingMode) (int64, bool) {
+	switch {
+	case toScale == fromScale:
+		return coeff, false
+	case toScale > fromScale:
+		product, over := mulOverflow(coeff, decimalPow10[toScale-fromScale])
+		if over || product < minDecimalAmountCoefficient || product > maxDecimalAmountCoefficient {
+			return 0, true
+		}
+		return product, false
+	default:
+		negative := coeff < 0
+		u := abs64(coeff)
+		d := uint64(decimalPow10[fromScale-toScale])
+		q := u / d
+		if roundUpMagnitude(rounding, q, u%d, d, negative) {
+			q++
+		}
+		if negative {
+			return -int64(q), false
+		}
+		return int64(q), false
+	}
+}

--- a/money/decimalamount.go
+++ b/money/decimalamount.go
@@ -519,33 +519,56 @@ func (a DecimalAmount) Equal(b DecimalAmount) bool {
 	return a.Cmp(b) == 0
 }
 
-// Add returns a + b. The result scale is the larger of the two scales.
-// Overflow yields ±Inf; +Inf + -Inf and any NaN operand yield NaN.
+// Add returns a + b. The result scale is the larger of the two scales, reduced
+// only when needed to keep the exact sum representable (so x + 0 is always x).
+// Overflow of the integer part yields ±Inf; +Inf + -Inf and any NaN operand
+// yield NaN.
 func (a DecimalAmount) Add(b DecimalAmount) DecimalAmount {
 	if r, ok := addNonFinite(a, b); ok {
 		return r
 	}
+	ca, cb := a.Coefficient(), b.Coefficient()
 	scale := a.Scale()
 	if bs := b.Scale(); bs > scale {
 		scale = bs
 	}
-	// Aligning to the larger scale only ever increases scale (pads with zeros),
-	// so no rounding happens and the mode is irrelevant. Alignment overflow
-	// means the dominant operand is unrepresentable at the target scale, so the
-	// result is that operand's infinity.
-	ac, aOver := scaleCoefficient(a.Coefficient(), a.Scale(), scale, RoundHalfAwayFromZero)
-	if aOver {
-		return decimalInf(a.Signbit())
+	// Align both to the common scale in 128-bit magnitudes (padding can exceed
+	// the 59-bit coefficient range, so int64 is not wide enough) and add with
+	// sign. Computing the true sum first — instead of rejecting a padded operand
+	// — lets near-cancelling terms produce a small, representable result.
+	negA, negB := ca < 0, cb < 0
+	aHi, aLo := bits.Mul64(abs64(ca), pow10u(scale-a.Scale()))
+	bHi, bLo := bits.Mul64(abs64(cb), pow10u(scale-b.Scale()))
+	var sumHi, sumLo uint64
+	var negSum bool
+	if negA == negB {
+		sumHi, sumLo = addU128(aHi, aLo, bHi, bLo)
+		negSum = negA
+	} else if cmpUint128(aHi, aLo, bHi, bLo) >= 0 {
+		sumHi, sumLo = subU128(aHi, aLo, bHi, bLo)
+		negSum = negA
+	} else {
+		sumHi, sumLo = subU128(bHi, bLo, aHi, aLo)
+		negSum = negB
 	}
-	bc, bOver := scaleCoefficient(b.Coefficient(), b.Scale(), scale, RoundHalfAwayFromZero)
-	if bOver {
-		return decimalInf(b.Signbit())
+	// Reduce the scale by stripping exact trailing zeros while the magnitude
+	// exceeds the coefficient range; only a genuinely too-large integer part
+	// (indivisible by 10) overflows to ±Inf.
+	for scale > 0 && (sumHi != 0 || sumLo > uint64(maxDecimalAmountCoefficient)) {
+		quoHi, quoLo, rem := div128by64(sumHi, sumLo, 10)
+		if rem != 0 {
+			break
+		}
+		sumHi, sumLo, scale = quoHi, quoLo, scale-1
 	}
-	sum, over := addOverflow(ac, bc)
-	if over || sum < minDecimalAmountCoefficient || sum > maxDecimalAmountCoefficient {
-		return decimalInf(ac < 0)
+	if sumHi != 0 || sumLo > uint64(maxDecimalAmountCoefficient) {
+		return decimalInf(negSum)
 	}
-	return packDecimalAmount(sum, scale)
+	coeff := int64(sumLo) //#nosec G115 -- sumLo is a bounded coefficient magnitude
+	if negSum {
+		coeff = -coeff
+	}
+	return packDecimalAmount(coeff, scale)
 }
 
 // Sub returns a - b. The result scale is the larger of the two scales.
@@ -871,10 +894,12 @@ func (a *DecimalAmount) UnmarshalBinary(data []byte) error {
 		return fmt.Errorf("money.DecimalAmount.UnmarshalBinary needs 8 bytes but got %d", len(data))
 	}
 	packed := int64(binary.BigEndian.Uint64(data)) //#nosec G115 -- restoring a bit pattern
-	if int(packed&scaleMask) > MaxDecimalAmountScale {
-		// Any scale above the maximum is non-finite; canonicalize it to scale
-		// nonFiniteScale from its coefficient sign.
-		switch coeff := packed >> scaleBits; {
+	scale := int(packed & scaleMask)
+	coeff := packed >> scaleBits
+	switch {
+	case scale == nonFiniteScale:
+		// Canonicalize the non-finite encoding from its coefficient sign.
+		switch {
 		case coeff > 0:
 			*a = decimalInf(false)
 		case coeff < 0:
@@ -882,9 +907,13 @@ func (a *DecimalAmount) UnmarshalBinary(data []byte) error {
 		default:
 			*a = DecimalAmountNaN()
 		}
-		return nil
+	case scale > MaxDecimalAmountScale:
+		return fmt.Errorf("money.DecimalAmount.UnmarshalBinary got invalid scale %d", scale)
+	case coeff < minDecimalAmountCoefficient || coeff > maxDecimalAmountCoefficient:
+		return fmt.Errorf("money.DecimalAmount.UnmarshalBinary got out-of-range coefficient %d", coeff)
+	default:
+		a.packed = packed
 	}
-	a.packed = packed
 	return nil
 }
 
@@ -942,19 +971,32 @@ func (a *DecimalAmount) Scan(value any) error {
 }
 
 // ScanString implements the strfmt scanning convention by parsing source as a
-// DecimalAmount. Parsing already rejects invalid input, so the validate flag
-// has no additional effect.
+// DecimalAmount. If validate is true, a non-finite result (NaN or ±Inf) is
+// rejected, mirroring Amount.ScanString.
 func (a *DecimalAmount) ScanString(source string, validate bool) error {
-	return a.scanParse(source)
+	parsed, err := ParseDecimalAmount(source)
+	if err != nil {
+		return err
+	}
+	if validate && !parsed.Valid() {
+		return fmt.Errorf("invalid money.DecimalAmount: %q", source)
+	}
+	*a = parsed
+	return nil
 }
 
 // JSONSchema returns the JSON Schema for a DecimalAmount as a numeric type,
 // matching the JSON number produced by MarshalJSON.
 func (DecimalAmount) JSONSchema() *jsonschema.Schema {
+	// Finite values marshal as a JSON number; non-finite values marshal as the
+	// quoted strings "NaN", "Inf" or "-Inf", so the schema allows either.
 	return &jsonschema.Schema{
-		Type:        "number",
 		Title:       "Decimal Amount",
-		Description: "Exact fixed-point monetary amount",
+		Description: `Exact fixed-point monetary amount; a JSON number, or "NaN"/"Inf"/"-Inf" for non-finite values`,
+		OneOf: []*jsonschema.Schema{
+			{Type: "number"},
+			{Type: "string"},
+		},
 	}
 }
 
@@ -1123,15 +1165,6 @@ func mulOverflow(a, b int64) (int64, bool) {
 	return p, false
 }
 
-// addOverflow adds a and b and reports signed overflow.
-func addOverflow(a, b int64) (int64, bool) {
-	s := a + b
-	if (a > 0 && b > 0 && s < 0) || (a < 0 && b < 0 && s >= 0) {
-		return 0, true
-	}
-	return s, false
-}
-
 // pow10u returns 10^scale as a uint64 for 0 ≤ scale ≤ MaxDecimalAmountScale.
 func pow10u(scale int) uint64 {
 	return uint64(decimalPow10[scale]) //#nosec G115 -- 10^scale is a positive int64
@@ -1162,6 +1195,22 @@ func signOf(x int64) int {
 	default:
 		return 0
 	}
+}
+
+// addU128 returns the 128-bit sum of (h1,l1) and (h2,l2). The final carry is
+// dropped: callers only add aligned coefficient magnitudes (< 2^119).
+func addU128(h1, l1, h2, l2 uint64) (hi, lo uint64) {
+	lo, carry := bits.Add64(l1, l2, 0)
+	hi, _ = bits.Add64(h1, h2, carry)
+	return hi, lo
+}
+
+// subU128 returns (h1,l1) - (h2,l2). The caller must ensure the first operand is
+// the larger magnitude so the result does not borrow past 128 bits.
+func subU128(h1, l1, h2, l2 uint64) (hi, lo uint64) {
+	lo, borrow := bits.Sub64(l1, l2, 0)
+	hi, _ = bits.Sub64(h1, h2, borrow)
+	return hi, lo
 }
 
 // cmpUint128 compares two 128-bit unsigned values (hi, lo), returning -1, 0 or +1.

--- a/money/decimalamount.go
+++ b/money/decimalamount.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io"
 	"math"
-	"math/big"
 	"math/bits"
 	"slices"
 	"strconv"
@@ -136,6 +135,30 @@ const (
 	minDecimalAmountCoefficient = -maxDecimalAmountCoefficient
 )
 
+// pow5[i] == 5^i for i in 0..MaxDecimalAmountScale (5^18 < 2^42), used by the
+// int128 float-to-decimal conversion.
+var pow5 = [MaxDecimalAmountScale + 1]int64{
+	1,
+	5,
+	25,
+	125,
+	625,
+	3125,
+	15625,
+	78125,
+	390625,
+	1953125,
+	9765625,
+	48828125,
+	244140625,
+	1220703125,
+	6103515625,
+	30517578125,
+	152587890625,
+	762939453125,
+	3814697265625,
+}
+
 // decimalPow10[i] == 10^i for i in 0..MaxDecimalAmountScale.
 // 10^18 is the largest power of ten that fits in an int64.
 var decimalPow10 = [MaxDecimalAmountScale + 1]int64{
@@ -218,13 +241,13 @@ func (a DecimalAmount) Valid() bool {
 
 // IsNaN reports whether the amount is the not-a-number value.
 func (a DecimalAmount) IsNaN() bool {
-	return int(a.packed&scaleMask) == nonFiniteScale && a.Coefficient() == 0
+	return !a.IsFinite() && a.Coefficient() == 0
 }
 
 // IsInf reports whether the amount is an infinity of the given sign:
 // sign > 0 tests +Inf, sign < 0 tests -Inf, sign == 0 tests either.
 func (a DecimalAmount) IsInf(sign int) bool {
-	if int(a.packed&scaleMask) != nonFiniteScale {
+	if a.IsFinite() {
 		return false
 	}
 	c := a.Coefficient()
@@ -260,11 +283,15 @@ func DecimalAmountFromAmount(amount Amount, scale int, rounding RoundingMode) (D
 // coefficient is taken directly from the digits of str without a float64
 // round-trip, so values like 99999999999999.99 keep their last cent.
 //
-// The tokens "NaN", "Inf"/"+Inf" and "-Inf" parse to the corresponding
-// non-finite values. Scientific notation is rejected. If acceptedDecimals is
-// non-empty, the number of decimal places must be one of the listed values.
-// An error is returned if the value needs more than MaxDecimalAmountScale
-// decimal places or does not fit the coefficient range.
+// Like ParseAmount, a lone separator group is treated as a decimal separator,
+// not a thousands separator: "1,000" and "1'000" parse to 1.000 (== 1), not
+// 1000. Pass acceptedDecimals to reject such ambiguous inputs.
+//
+// The tokens "NaN", "Inf"/"+Inf"/"Infinity" and "-Inf"/"-Infinity" parse to the
+// corresponding non-finite values. Scientific notation is rejected. If
+// acceptedDecimals is non-empty, the number of decimal places must be one of the
+// listed values. An error is returned if the value needs more than
+// MaxDecimalAmountScale decimal places or does not fit the coefficient range.
 func ParseDecimalAmount(str string, acceptedDecimals ...int) (DecimalAmount, error) {
 	// The long "Infinity" spellings are not recognized by float.ParseDetails but
 	// are the PostgreSQL numeric literals emitted by Value.
@@ -350,7 +377,18 @@ func (a DecimalAmount) Ptr() *DecimalAmount {
 }
 
 // Float returns the amount as a float64, which may lose precision.
+// The non-finite states map to their float64 equivalents (NaN, ±Inf).
 func (a DecimalAmount) Float() float64 {
+	if !a.IsFinite() {
+		switch {
+		case a.IsNaN():
+			return math.NaN()
+		case a.Signbit():
+			return math.Inf(-1)
+		default:
+			return math.Inf(1)
+		}
+	}
 	return float64(a.Coefficient()) / float64(decimalPow10[a.Scale()])
 }
 
@@ -428,11 +466,25 @@ func (a DecimalAmount) Cmp(b DecimalAmount) int {
 				return 0
 			}
 		}
-		// Different scales: cross-multiply with big.Int to avoid overflow.
-		// a < b  <=>  a.coeff·10^b.scale < b.coeff·10^a.scale
-		ai := new(big.Int).Mul(big.NewInt(a.Coefficient()), big.NewInt(decimalPow10[bs]))
-		bi := new(big.Int).Mul(big.NewInt(b.Coefficient()), big.NewInt(decimalPow10[as]))
-		return ai.Cmp(bi)
+		// Different scales: compare a.coeff·10^b.scale vs b.coeff·10^a.scale.
+		// Both cross-products fit in 128 bits (coeff ≤ 2^58, 10^scale ≤ 10^18),
+		// so compare signs first, then magnitudes with 128-bit integers.
+		ac, bc := a.Coefficient(), b.Coefficient()
+		if sa, sb := signOf(ac), signOf(bc); sa != sb {
+			if sa < sb {
+				return -1
+			}
+			return +1
+		} else if sa == 0 {
+			return 0 // both zero
+		}
+		aHi, aLo := bits.Mul64(abs64(ac), pow10u(bs))
+		bHi, bLo := bits.Mul64(abs64(bc), pow10u(as))
+		cmp := cmpUint128(aHi, aLo, bHi, bLo)
+		if ac < 0 {
+			cmp = -cmp // both negative: larger magnitude is the smaller value
+		}
+		return cmp
 	}
 	switch ra, rb := a.orderRank(), b.orderRank(); {
 	case ra < rb:
@@ -565,7 +617,7 @@ func (a DecimalAmount) Mul(b DecimalAmount, rounding RoundingMode) DecimalAmount
 	// Exact product coefficient ca·cb has scale a.Scale()+b.Scale(); dividing
 	// by 10^b.Scale() brings it to the target scale a.Scale().
 	hi, lo := bits.Mul64(abs64(ca), abs64(cb))
-	return decimalDivRound(hi, lo, uint64(decimalPow10[b.Scale()]), negative, a.Scale(), rounding)
+	return decimalDivRound(hi, lo, pow10u(b.Scale()), negative, a.Scale(), rounding)
 }
 
 // Div returns a / b rounded to the scale of a using the given rounding mode.
@@ -585,7 +637,7 @@ func (a DecimalAmount) Div(b DecimalAmount, rounding RoundingMode) DecimalAmount
 	}
 	negative := (ca < 0) != (cb < 0)
 	// result_coeff = round( ca·10^b.Scale() / cb ) at scale a.Scale().
-	hi, lo := bits.Mul64(abs64(ca), uint64(decimalPow10[b.Scale()]))
+	hi, lo := bits.Mul64(abs64(ca), pow10u(b.Scale()))
 	return decimalDivRound(hi, lo, abs64(cb), negative, a.Scale(), rounding)
 }
 
@@ -710,20 +762,29 @@ func (a DecimalAmount) FormatSep(thousandsSep, decimalSep rune) string {
 func (a DecimalAmount) Format(f fmt.State, verb rune) {
 	if !a.IsFinite() {
 		if verb == 'v' && f.Flag('#') {
-			io.WriteString(f, a.GoString())
+			writeStr(f, a.GoString())
 			return
+		}
+		s := a.String() // "NaN", "Inf" or "-Inf"
+		if a.IsInf(1) {
+			if f.Flag('+') {
+				s = "+" + s
+			} else if f.Flag(' ') {
+				s = " " + s
+			}
 		}
 		if verb == 'q' {
-			writePadded(f, strconv.Quote(a.String()))
-			return
+			s = strconv.Quote(s)
 		}
-		writePadded(f, a.String())
+		// Non-finite tokens are never zero-padded, matching the standard
+		// library (e.g. "%08.2f" of +Inf is "     Inf", not "00000Inf").
+		writeSpacePadded(f, s)
 		return
 	}
 	switch verb {
 	case 'v':
 		if f.Flag('#') {
-			io.WriteString(f, a.GoString())
+			writeStr(f, a.GoString())
 			return
 		}
 		writePadded(f, a.formatBody(f, a.Scale()))
@@ -810,9 +871,9 @@ func (a *DecimalAmount) UnmarshalBinary(data []byte) error {
 		return fmt.Errorf("money.DecimalAmount.UnmarshalBinary needs 8 bytes but got %d", len(data))
 	}
 	packed := int64(binary.BigEndian.Uint64(data)) //#nosec G115 -- restoring a bit pattern
-	scale := int(packed & scaleMask)
-	if scale == nonFiniteScale {
-		// Canonicalize the non-finite encoding from its coefficient sign.
+	if int(packed&scaleMask) > MaxDecimalAmountScale {
+		// Any scale above the maximum is non-finite; canonicalize it to scale
+		// nonFiniteScale from its coefficient sign.
 		switch coeff := packed >> scaleBits; {
 		case coeff > 0:
 			*a = decimalInf(false)
@@ -822,9 +883,6 @@ func (a *DecimalAmount) UnmarshalBinary(data []byte) error {
 			*a = DecimalAmountNaN()
 		}
 		return nil
-	}
-	if scale > MaxDecimalAmountScale {
-		return fmt.Errorf("money.DecimalAmount.UnmarshalBinary got invalid scale %d", scale)
 	}
 	a.packed = packed
 	return nil
@@ -850,7 +908,8 @@ func (a DecimalAmount) Value() (driver.Value, error) {
 
 // Scan implements the database/sql.Scanner interface and accepts string,
 // []byte, int64 and float64. A float64 is converted via its shortest exact
-// decimal representation.
+// decimal representation, or rounded to MaxDecimalAmountScale if that needs
+// more fractional digits.
 func (a *DecimalAmount) Scan(value any) error {
 	switch x := value.(type) {
 	case string:
@@ -864,15 +923,27 @@ func (a *DecimalAmount) Scan(value any) error {
 		*a = packDecimalAmount(x, 0)
 		return nil
 	case float64:
-		return a.scanParse(strconv.FormatFloat(x, 'f', -1, 64))
+		// Use the shortest exact decimal when it fits; a value needing more
+		// than MaxDecimalAmountScale fractional digits is rounded to that scale
+		// rather than rejected.
+		if parsed, err := ParseDecimalAmount(strconv.FormatFloat(x, 'f', -1, 64)); err == nil {
+			*a = parsed
+			return nil
+		}
+		parsed, err := DecimalAmountFromFloat(x, MaxDecimalAmountScale, RoundHalfAwayFromZero)
+		if err != nil {
+			return err
+		}
+		*a = parsed
+		return nil
 	default:
 		return fmt.Errorf("can't scan value of type %T as money.DecimalAmount", value)
 	}
 }
 
 // ScanString implements the strfmt scanning convention by parsing source as a
-// DecimalAmount. Because a DecimalAmount is always finite and exact, the
-// validate flag has no additional effect.
+// DecimalAmount. Parsing already rejects invalid input, so the validate flag
+// has no additional effect.
 func (a *DecimalAmount) ScanString(source string, validate bool) error {
 	return a.scanParse(source)
 }
@@ -990,27 +1061,44 @@ func writeGrouped(b *strings.Builder, intPart string, sep rune) {
 	}
 }
 
+// writeSpacePadded writes s to f padded with spaces to the field width,
+// honoring the '-' (left-align) flag but never the '0' flag. Used for
+// non-finite tokens, which the standard library never zero-pads.
+func writeSpacePadded(f fmt.State, s string) {
+	width, ok := f.Width()
+	if !ok || len(s) >= width {
+		writeStr(f, s)
+		return
+	}
+	pad := strings.Repeat(" ", width-len(s))
+	if f.Flag('-') {
+		writeStr(f, s+pad)
+	} else {
+		writeStr(f, pad+s)
+	}
+}
+
 // writePadded writes s to f, applying the width and the '-' and '0' padding
 // flags. s is expected to be ASCII (digits, sign, '.', ',', '"').
 func writePadded(f fmt.State, s string) {
 	width, ok := f.Width()
 	if !ok || len(s) >= width {
-		io.WriteString(f, s)
+		writeStr(f, s)
 		return
 	}
 	pad := strings.Repeat(padByte(f), width-len(s))
 	switch {
 	case f.Flag('-'):
-		io.WriteString(f, s)
-		io.WriteString(f, pad)
+		writeStr(f, s)
+		writeStr(f, pad)
 	case f.Flag('0') && len(s) > 0 && (s[0] == '-' || s[0] == '+' || s[0] == ' '):
 		// Zero-pad after the sign so it stays leftmost.
-		io.WriteString(f, s[:1])
-		io.WriteString(f, pad)
-		io.WriteString(f, s[1:])
+		writeStr(f, s[:1])
+		writeStr(f, pad)
+		writeStr(f, s[1:])
 	default:
-		io.WriteString(f, pad)
-		io.WriteString(f, s)
+		writeStr(f, pad)
+		writeStr(f, s)
 	}
 }
 
@@ -1044,6 +1132,17 @@ func addOverflow(a, b int64) (int64, bool) {
 	return s, false
 }
 
+// pow10u returns 10^scale as a uint64 for 0 ≤ scale ≤ MaxDecimalAmountScale.
+func pow10u(scale int) uint64 {
+	return uint64(decimalPow10[scale]) //#nosec G115 -- 10^scale is a positive int64
+}
+
+// writeStr writes s to the fmt.State f, discarding the write error, which a
+// fmt.State never produces meaningfully.
+func writeStr(f fmt.State, s string) {
+	_, _ = io.WriteString(f, s) //#nosec G104 -- writing to a fmt.State cannot fail meaningfully
+}
+
 // abs64 returns the magnitude of x as an unsigned integer. It is safe for every
 // value in the coefficient range, which never reaches math.MinInt64.
 func abs64(x int64) uint64 {
@@ -1051,6 +1150,34 @@ func abs64(x int64) uint64 {
 		return uint64(-x)
 	}
 	return uint64(x)
+}
+
+// signOf returns -1, 0 or +1 for the sign of x.
+func signOf(x int64) int {
+	switch {
+	case x < 0:
+		return -1
+	case x > 0:
+		return +1
+	default:
+		return 0
+	}
+}
+
+// cmpUint128 compares two 128-bit unsigned values (hi, lo), returning -1, 0 or +1.
+func cmpUint128(aHi, aLo, bHi, bLo uint64) int {
+	switch {
+	case aHi < bHi:
+		return -1
+	case aHi > bHi:
+		return +1
+	case aLo < bLo:
+		return -1
+	case aLo > bLo:
+		return +1
+	default:
+		return 0
+	}
 }
 
 // decimalDivRound divides the 128-bit magnitude (numHi, numLo) by divisor,
@@ -1195,22 +1322,11 @@ func roundAwayFromZero(mode RoundingMode, negative, quotientOdd bool, halfCmp in
 	}
 }
 
-// roundBigQuotient reports whether the truncated quotient quo = num/den (with
-// remainder rem, den > 0) should have its magnitude incremented under the
-// rounding mode.
-func roundBigQuotient(mode RoundingMode, quo, rem, den *big.Int, negative bool) bool {
-	if rem.Sign() == 0 {
-		return false
-	}
-	twiceRem := new(big.Int).Lsh(new(big.Int).Abs(rem), 1)
-	return roundAwayFromZero(mode, negative, quo.Bit(0) == 1, twiceRem.Cmp(den))
-}
-
 // decimalFromFloatRounded converts f to a DecimalAmount at the given scale using
-// the exact value of the binary float64 and the given rounding mode. A NaN or
-// infinite f maps to the corresponding non-finite DecimalAmount and an
-// out-of-range value maps to ±Inf. It returns an error only for an out-of-range
-// scale (a programmer error).
+// the exact value of the binary float64 and the given rounding mode, computed in
+// 128-bit integer arithmetic without heap allocation. A NaN or infinite f maps
+// to the corresponding non-finite DecimalAmount and an out-of-range value maps to
+// ±Inf. It returns an error only for an out-of-range scale (a programmer error).
 func decimalFromFloatRounded(f float64, scale int, rounding RoundingMode) (DecimalAmount, error) {
 	if scale < 0 || scale > MaxDecimalAmountScale {
 		return DecimalAmount{}, fmt.Errorf("money.DecimalAmount scale %d out of range [0, %d]", scale, MaxDecimalAmountScale)
@@ -1220,29 +1336,114 @@ func decimalFromFloatRounded(f float64, scale int, rounding RoundingMode) (Decim
 		return DecimalAmountNaN(), nil
 	case math.IsInf(f, 0):
 		return decimalInf(math.Signbit(f)), nil
+	case f == 0:
+		return packDecimalAmount(0, scale), nil
 	}
-	// Exact value of f, scaled by 10^scale, as a rational num/den (den > 0).
-	r := new(big.Rat).SetFloat64(f)
-	r.Mul(r, new(big.Rat).SetInt64(decimalPow10[scale]))
-	num, den := r.Num(), r.Denom()
-	quo := new(big.Int)
-	rem := new(big.Int)
-	quo.QuoRem(num, den, rem) // truncated toward zero
-	if roundBigQuotient(rounding, quo, rem, den, num.Sign() < 0) {
-		if num.Sign() < 0 {
-			quo.Sub(quo, big.NewInt(1))
-		} else {
-			quo.Add(quo, big.NewInt(1))
-		}
+	// Decompose |f| exactly as m·2^e with m a 53-bit integer mantissa. Then
+	// value·10^scale = m·2^e·10^scale = (m·5^scale)·2^(e+scale). Since m ≤ 2^53
+	// and 5^scale < 2^42, the product m·5^scale fits in 128 bits, and the
+	// remaining factor is a pure power of two, i.e. a shift.
+	negative := math.Signbit(f)
+	frac, exp := math.Frexp(f) // f = frac·2^exp, 0.5 ≤ |frac| < 1
+	m := uint64(math.Ldexp(math.Abs(frac), 53))
+	hi, lo := bits.Mul64(m, uint64(pow5[scale])) //#nosec G115 -- 5^scale is a positive int64
+	var mag uint64
+	var over bool
+	if s := (exp - 53) + scale; s >= 0 {
+		mag, over = shiftLeft128(hi, lo, s) // exact, no rounding
+	} else {
+		mag, over = shiftRightRound128(hi, lo, -s, negative, rounding)
 	}
-	if !quo.IsInt64() {
-		return decimalInf(f < 0), nil
+	if over || mag > uint64(maxDecimalAmountCoefficient) {
+		return decimalInf(negative), nil
 	}
-	coeff := quo.Int64()
-	if coeff < minDecimalAmountCoefficient || coeff > maxDecimalAmountCoefficient {
-		return decimalInf(f < 0), nil
+	coeff := int64(mag)
+	if negative {
+		coeff = -coeff
 	}
 	return packDecimalAmount(coeff, scale), nil
+}
+
+// shiftLeft128 returns ((hi,lo) << n) as a uint64, reporting overflow if the
+// result does not fit in 64 bits (the coefficient range is below 2^64).
+func shiftLeft128(hi, lo uint64, n int) (uint64, bool) {
+	if hi != 0 {
+		return 0, true // value ≥ 2^64, shifting left only grows it
+	}
+	if n >= 64 {
+		return 0, lo != 0
+	}
+	r := lo << n
+	if r>>n != lo {
+		return 0, true // high bits shifted out
+	}
+	return r, false
+}
+
+// shiftRightRound128 returns round((hi,lo) / 2^k) as a uint64 using the rounding
+// mode and sign, reporting overflow if the quotient does not fit in 64 bits.
+func shiftRightRound128(hi, lo uint64, k int, negative bool, rounding RoundingMode) (uint64, bool) {
+	var qHi, qLo uint64
+	switch {
+	case k == 0:
+		qHi, qLo = hi, lo
+	case k < 64:
+		qLo = lo>>k | hi<<(64-k)
+		qHi = hi >> k
+	case k < 128:
+		qLo = hi >> (k - 64)
+	}
+	if qHi != 0 {
+		return 0, true
+	}
+	// The bits shifted out determine rounding: the round bit is bit k-1 and the
+	// sticky bit is any set bit below it.
+	roundBit := bit128(hi, lo, k-1)
+	sticky := lowBitsNonzero128(hi, lo, k-1)
+	if roundBit == 0 && !sticky {
+		return qLo, false // exact
+	}
+	halfCmp := -1 // remainder below the halfway point
+	if roundBit != 0 {
+		if sticky {
+			halfCmp = +1 // above halfway
+		} else {
+			halfCmp = 0 // exactly halfway
+		}
+	}
+	if roundAwayFromZero(rounding, negative, qLo&1 == 1, halfCmp) {
+		qLo++
+		if qLo == 0 { // wrapped past uint64
+			return 0, true
+		}
+	}
+	return qLo, false
+}
+
+// bit128 returns bit i (0-based) of the 128-bit value (hi,lo), or 0 out of range.
+func bit128(hi, lo uint64, i int) uint64 {
+	switch {
+	case i < 0 || i >= 128:
+		return 0
+	case i < 64:
+		return lo >> i & 1
+	default:
+		return hi >> (i - 64) & 1
+	}
+}
+
+// lowBitsNonzero128 reports whether any of bits [0, n) of (hi,lo) are set.
+func lowBitsNonzero128(hi, lo uint64, n int) bool {
+	switch {
+	case n <= 0:
+		return false
+	case n >= 128:
+		return hi != 0 || lo != 0
+	case n <= 64:
+		return lo&(1<<n-1) != 0
+	default:
+		return lo != 0 || hi&(1<<(n-64)-1) != 0
+	}
 }
 
 // scaleCoefficient returns coeff represented at toScale instead of fromScale and
@@ -1262,14 +1463,15 @@ func scaleCoefficient(coeff int64, fromScale, toScale int, rounding RoundingMode
 	default:
 		negative := coeff < 0
 		u := abs64(coeff)
-		d := uint64(decimalPow10[fromScale-toScale])
+		d := pow10u(fromScale - toScale)
 		q := u / d
 		if roundUpMagnitude(rounding, q, u%d, d, negative) {
 			q++
 		}
+		// q is a bounded coefficient magnitude ≤ maxDecimalAmountCoefficient.
 		if negative {
-			return -int64(q), false
+			return -int64(q), false //#nosec G115 -- q is a bounded coefficient magnitude
 		}
-		return int64(q), false
+		return int64(q), false //#nosec G115 -- q is a bounded coefficient magnitude
 	}
 }

--- a/money/decimalamount.go
+++ b/money/decimalamount.go
@@ -956,12 +956,20 @@ func (a DecimalAmount) MarshalJSON() ([]byte, error) {
 // decimal string, or null. null and "" are decoded as zero.
 func (a *DecimalAmount) UnmarshalJSON(data []byte) error {
 	s := string(data)
-	if s == "null" || s == `""` {
+	if s == "null" {
 		*a = DecimalAmount{}
 		return nil
 	}
-	if l := len(s); l >= 2 && s[0] == '"' && s[l-1] == '"' {
-		s = s[1 : l-1]
+	// Decode a JSON string through the standard library so \uXXXX and other
+	// escape sequences are resolved, not just the surrounding quotes stripped.
+	if len(s) > 0 && s[0] == '"' {
+		if err := json.Unmarshal(data, &s); err != nil {
+			return fmt.Errorf("can't unmarshal JSON %s as money.DecimalAmount: %w", data, err)
+		}
+	}
+	if s == "" {
+		*a = DecimalAmount{}
+		return nil
 	}
 	parsed, err := ParseDecimalAmount(s)
 	if err != nil {

--- a/money/decimalamount_test.go
+++ b/money/decimalamount_test.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"math/big"
+	"math/rand"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -420,10 +422,12 @@ func TestDecimalAmount_Binary(t *testing.T) {
 
 	var got DecimalAmount
 	assert.Error(t, got.UnmarshalBinary([]byte{1, 2, 3}))
-	// A scale > MaxDecimalAmountScale in the low bits must be rejected.
-	bad := make([]byte, 8)
-	bad[7] = 19
-	assert.Error(t, got.UnmarshalBinary(bad))
+	// Any scale > MaxDecimalAmountScale is non-finite; a scale-19 zero
+	// coefficient canonicalizes to NaN rather than being rejected.
+	nonCanonical := make([]byte, 8)
+	nonCanonical[7] = 19
+	require.NoError(t, got.UnmarshalBinary(nonCanonical))
+	assert.True(t, got.IsNaN())
 }
 
 func TestDecimalAmount_SQL(t *testing.T) {
@@ -520,6 +524,134 @@ func TestDecimalAmount_MarshalJSONValidNumber(t *testing.T) {
 		require.NoError(t, err)
 		assert.True(t, json.Valid(data), "invalid JSON %q", data)
 		assert.False(t, bytes.HasPrefix(data, []byte(`"`)), "should be a number, got %q", data)
+	}
+}
+
+func TestDecimalAmount_nonFiniteNoPanic(t *testing.T) {
+	nan := DecimalAmountNaN()
+	posInf := DecimalAmountInf(1)
+	negInf := DecimalAmountInf(-1)
+
+	// Float()/Amount() must not panic on non-finite values (regression).
+	assert.True(t, math.IsNaN(nan.Float()))
+	assert.True(t, math.IsInf(posInf.Float(), 1))
+	assert.True(t, math.IsInf(negInf.Float(), -1))
+	assert.True(t, math.IsNaN(float64(nan.Amount())))
+	assert.True(t, math.IsInf(float64(posInf.Amount()), 1))
+	assert.True(t, math.IsInf(float64(CurrencyDecimalAmountEUR(posInf).CurrencyAmount().Amount), 1))
+
+	// Rate methods on a non-finite receiver propagate instead of panicking.
+	assert.True(t, posInf.MultipliedByRate(Rate(2), 2, RoundHalfAwayFromZero).IsInf(1))
+	assert.True(t, negInf.DividedByRate(Rate(2), 2, RoundHalfAwayFromZero).IsInf(-1))
+	assert.True(t, nan.Percentage(50, 2, RoundHalfAwayFromZero).IsNaN())
+
+	// fmt: non-finite tokens are space-padded (never zero-padded) and honor the
+	// sign flag on +Inf, matching the standard library.
+	assert.Equal(t, "     Inf", fmt.Sprintf("%08.2f", posInf))
+	assert.Equal(t, "    -Inf", fmt.Sprintf("%8.2f", negInf))
+	assert.Equal(t, "     NaN", fmt.Sprintf("%08.2f", nan))
+	assert.Equal(t, "+Inf", fmt.Sprintf("%+f", posInf))
+	assert.Equal(t, "Inf   ", fmt.Sprintf("%-6.2f", posInf))
+	// The padded token still round-trips.
+	rt, err := ParseDecimalAmount("Inf")
+	require.NoError(t, err)
+	assert.True(t, rt.IsInf(1))
+
+	// Scan(float64) rounds a value that needs >18 decimals instead of erroring.
+	var scanned DecimalAmount
+	require.NoError(t, scanned.Scan(1e-19))
+	assert.True(t, scanned.IsZero())
+	require.NoError(t, scanned.Scan(12.5))
+	assert.Equal(t, "12.5", scanned.String())
+}
+
+// floatToDecimalOracle is an independent big.Rat reference for
+// decimalFromFloatRounded, used to validate the int128 implementation.
+func floatToDecimalOracle(f float64, scale int, mode RoundingMode) DecimalAmount {
+	switch {
+	case math.IsNaN(f):
+		return DecimalAmountNaN()
+	case math.IsInf(f, 0):
+		return decimalInf(math.Signbit(f))
+	}
+	r := new(big.Rat).SetFloat64(f)
+	pow := new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(scale)), nil)
+	r.Mul(r, new(big.Rat).SetInt(pow))
+	num, den := r.Num(), r.Denom()
+	quo, rem := new(big.Int), new(big.Int)
+	quo.QuoRem(num, den, rem)
+	negative := num.Sign() < 0
+	if rem.Sign() != 0 {
+		twiceRem := new(big.Int).Lsh(new(big.Int).Abs(rem), 1)
+		if roundAwayFromZero(mode, negative, quo.Bit(0) == 1, twiceRem.Cmp(den)) {
+			if negative {
+				quo.Sub(quo, big.NewInt(1))
+			} else {
+				quo.Add(quo, big.NewInt(1))
+			}
+		}
+	}
+	if !quo.IsInt64() {
+		return decimalInf(negative)
+	}
+	c := quo.Int64()
+	if c < minDecimalAmountCoefficient || c > maxDecimalAmountCoefficient {
+		return decimalInf(negative)
+	}
+	return packDecimalAmount(c, scale)
+}
+
+func TestDecimalAmount_FromFloatOracle(t *testing.T) {
+	values := []float64{
+		0, math.Copysign(0, -1), 1, -1, 0.5, -0.5, 0.25, 0.125, 0.0625,
+		1.5, 2.5, 12.5, 0.375, 2.675, 1.005, 100.0 / 3, 1.0 / 3, 2.0 / 3,
+		1234.56, -99.99, 0.1, 0.2, 0.3, 9.99999999, 123456789.123456,
+		1e-9, 1e-15, 1e-18, 1e-19, 1e-20, 5e-10,
+		1e6, 1e12, 1e15, 1e17, 2.8e17, 1e18, 1e19, 1e30,
+		math.SmallestNonzeroFloat64, math.MaxFloat64,
+		math.Nextafter(0.5, 1), math.Nextafter(0.5, 0),
+	}
+	modes := []RoundingMode{
+		RoundHalfAwayFromZero, RoundHalfToEven, RoundHalfUp, RoundHalfDown,
+		RoundDown, RoundUp, RoundFloor, RoundCeil,
+	}
+	rng := rand.New(rand.NewSource(1))
+	for range 4000 {
+		// Add random floats across a wide exponent range, both signs.
+		values = append(values, math.Ldexp(rng.Float64()-0.5, rng.Intn(200)-100))
+	}
+	for _, f := range values {
+		for scale := 0; scale <= MaxDecimalAmountScale; scale++ {
+			for _, mode := range modes {
+				want := floatToDecimalOracle(f, scale, mode)
+				got, err := DecimalAmountFromFloat(f, scale, mode)
+				require.NoError(t, err)
+				if want != got {
+					t.Fatalf("FromFloat(%v, %d, %s) = %s (packed %d), want %s (packed %d)",
+						f, scale, mode, got, got, want, want)
+				}
+			}
+		}
+	}
+}
+
+func TestDecimalAmount_CmpInt128(t *testing.T) {
+	// Exercise the 128-bit cross-scale comparison path with signs and magnitudes.
+	cases := []struct {
+		a, b DecimalAmount
+		want int
+	}{
+		{NewDecimalAmount(150, 2), NewDecimalAmount(15, 1), 0},    // 1.50 == 1.5
+		{NewDecimalAmount(151, 2), NewDecimalAmount(15, 1), 1},    // 1.51 > 1.5
+		{NewDecimalAmount(-151, 2), NewDecimalAmount(-15, 1), -1}, // -1.51 < -1.5
+		{NewDecimalAmount(-1, 0), NewDecimalAmount(1, 5), -1},     // negative < positive
+		{NewDecimalAmount(0, 0), NewDecimalAmount(0, 8), 0},       // zeros equal across scales
+		{NewDecimalAmount(maxDecimalAmountCoefficient, 0), NewDecimalAmount(1, 18), 1},
+		{NewDecimalAmount(minDecimalAmountCoefficient, 0), NewDecimalAmount(-1, 18), -1},
+	}
+	for _, c := range cases {
+		assert.Equal(t, c.want, c.a.Cmp(c.b), "%s cmp %s", c.a, c.b)
+		assert.Equal(t, -c.want, c.b.Cmp(c.a), "%s cmp %s (reversed)", c.b, c.a)
 	}
 }
 

--- a/money/decimalamount_test.go
+++ b/money/decimalamount_test.go
@@ -278,6 +278,65 @@ func TestDecimalAmount_AddOracle(t *testing.T) {
 	}
 }
 
+// TestDecimalAmount_MulDivOracle verifies the max-precision contract of Mul
+// and Div against big.Rat: the result is exact whenever the true value is
+// representable, rounding (half away from zero here) only touches the last
+// representable digit, and ±Inf occurs only for a true integer-part overflow.
+func TestDecimalAmount_MulDivOracle(t *testing.T) {
+	rng := rand.New(rand.NewSource(3))
+	randDec := func() DecimalAmount {
+		// Mix small and full-range coefficients so exact results, forced
+		// rounding and overflow all occur.
+		coeff := rng.Int63n(2*maxDecimalAmountCoefficient+1) - maxDecimalAmountCoefficient
+		if rng.Intn(2) == 0 {
+			coeff = rng.Int63n(20001) - 10000
+		}
+		return NewDecimalAmount(coeff, rng.Intn(MaxDecimalAmountScale+1))
+	}
+	toRat := func(d DecimalAmount) *big.Rat {
+		r := new(big.Rat).SetInt64(d.Coefficient())
+		return r.Quo(r, new(big.Rat).SetInt(new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(d.Scale())), nil)))
+	}
+	maxc := big.NewInt(maxDecimalAmountCoefficient)
+	check := func(op string, a, b, got DecimalAmount, want *big.Rat) {
+		t.Helper()
+		if got.IsInf(0) {
+			// ±Inf only when even the integer part exceeds the coefficient range.
+			require.Truef(t, new(big.Rat).Abs(want).Cmp(new(big.Rat).SetInt(maxc)) > 0,
+				"%s(%s,%s)=Inf but |%s| fits the coefficient range", op, a, b, want.FloatString(25))
+			return
+		}
+		if toRat(got).Cmp(want) == 0 {
+			return // exact result
+		}
+		// Rounded result: the error is at most half an ulp of the result scale
+		// (RoundHalfAwayFromZero) ...
+		diff := new(big.Rat).Sub(toRat(got), want)
+		diff.Abs(diff)
+		halfUlp := big.NewRat(1, 2)
+		halfUlp.Quo(halfUlp, new(big.Rat).SetInt(new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(got.Scale())), nil)))
+		require.Truef(t, diff.Cmp(halfUlp) <= 0,
+			"%s(%s,%s)=%s deviates from %s by more than half an ulp", op, a, b, got, want.FloatString(25))
+		// ... and only happens because one more decimal place cannot fit:
+		// rounding |want| half away from zero at scale+1 would exceed the
+		// coefficient range, i.e. |want|·10^(scale+1) ≥ max + 1/2.
+		if got.Scale() < MaxDecimalAmountScale {
+			scaled := new(big.Rat).Abs(want)
+			scaled.Mul(scaled, new(big.Rat).SetInt(new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(got.Scale()+1)), nil)))
+			limit := new(big.Rat).Add(new(big.Rat).SetInt(maxc), big.NewRat(1, 2))
+			require.Truef(t, scaled.Cmp(limit) >= 0,
+				"%s(%s,%s)=%s was rounded although scale %d is not maximal", op, a, b, got, got.Scale())
+		}
+	}
+	for range 20000 {
+		a, b := randDec(), randDec()
+		check("Mul", a, b, a.Mul(b, RoundHalfAwayFromZero), new(big.Rat).Mul(toRat(a), toRat(b)))
+		if !b.IsZero() {
+			check("Div", a, b, a.Div(b, RoundHalfAwayFromZero), new(big.Rat).Quo(toRat(a), toRat(b)))
+		}
+	}
+}
+
 func TestDecimalAmount_ScanStringValidate(t *testing.T) {
 	var d DecimalAmount
 	// validate=true rejects non-finite input (mirrors Amount.ScanString).
@@ -309,6 +368,12 @@ func TestDecimalAmount_MulInt(t *testing.T) {
 	assert.Equal(t, a.MulInt(3), a.MulInt64(3))
 	assert.True(t, NewDecimalAmount(maxDecimalAmountCoefficient, 0).MulInt64(2).IsInf(1))
 	assert.True(t, NewDecimalAmount(minDecimalAmountCoefficient, 0).MulInt(2).IsInf(-1))
+
+	// A coefficient overflow with exact trailing zeros reduces the scale
+	// instead of overflowing to Inf.
+	assert.Equal(t,
+		NewDecimalAmount(maxDecimalAmountCoefficient, 0),
+		NewDecimalAmount(maxDecimalAmountCoefficient, 2).MulInt(100))
 }
 
 func TestDecimalAmount_Mul(t *testing.T) {
@@ -316,25 +381,36 @@ func TestDecimalAmount_Mul(t *testing.T) {
 		a, b DecimalAmount
 		want string
 	}{
-		// Result takes the scale of a.
-		{NewDecimalAmount(150, 2), NewDecimalAmount(150, 2), "2.25"}, // 1.50 * 1.50
-		{NewDecimalAmount(10, 1), NewDecimalAmount(10, 1), "1.0"},    // 1.0 * 1.0
-		{NewDecimalAmount(3, 0), NewDecimalAmount(4, 0), "12"},       // 3 * 4
-		{NewDecimalAmount(-2, 0), NewDecimalAmount(150, 2), "-3"},    // -2 * 1.50 -> -3.00 at scale 0
-		{NewDecimalAmount(100, 2), NewDecimalAmount(119, 2), "1.19"}, // 1.00 * 1.19
-		// Rounding to a's scale, half away from zero.
-		{NewDecimalAmount(11, 1), NewDecimalAmount(11, 1), "1.2"}, // 1.1 * 1.1 = 1.21 -> 1.2
+		// The exact product keeps the full precision: the result scale is the
+		// sum of the operand scales.
+		{NewDecimalAmount(150, 2), NewDecimalAmount(150, 2), "2.2500"},     // 1.50 * 1.50
+		{NewDecimalAmount(10, 1), NewDecimalAmount(10, 1), "1.00"},         // 1.0 * 1.0
+		{NewDecimalAmount(3, 0), NewDecimalAmount(4, 0), "12"},             // 3 * 4
+		{NewDecimalAmount(-2, 0), NewDecimalAmount(150, 2), "-3.00"},       // -2 * 1.50
+		{NewDecimalAmount(100, 2), NewDecimalAmount(119, 2), "1.1900"},     // 1.00 * 1.19
+		{NewDecimalAmount(11, 1), NewDecimalAmount(11, 1), "1.21"},         // 1.1 * 1.1 stays exact
+		{NewDecimalAmount(105, 4), NewDecimalAmount(105, 4), "0.00011025"}, // 0.0105²
 	}
 	for _, c := range cases {
 		got := c.a.Mul(c.b, RoundHalfAwayFromZero)
 		assert.Equal(t, c.want, got.String(), "%s * %s", c.a, c.b)
-		assert.Equal(t, c.a.Scale(), got.Scale())
+		assert.Equal(t, c.a.Scale()+c.b.Scale(), got.Scale())
 	}
 
-	// Large product whose exact 128-bit intermediate exceeds 64 bits:
-	// 5.000000000 * 5.000000000 = 25.000000000 (product 2.5e19 needs 65 bits).
+	// Large product whose exact 128-bit intermediate exceeds 64 bits and whose
+	// coefficient at scale 18 exceeds the coefficient range: the scale is
+	// reduced by stripping exact trailing zeros, losing no data.
+	// 5.000000000 * 5.000000000 = 25 with 16 remaining zero decimals.
 	x := NewDecimalAmount(5_000_000_000, 9)
-	assert.Equal(t, "25.000000000", x.Mul(x, RoundHalfAwayFromZero).String())
+	assert.Equal(t, "25.0000000000000000", x.Mul(x, RoundHalfAwayFromZero).String())
+	assert.Equal(t, 16, x.Mul(x, RoundHalfAwayFromZero).Scale())
+
+	// A product needing more than the representable precision is rounded with
+	// the given mode at the largest scale that fits (this is the only case
+	// where Mul rounds): 0.111111111111111111 * 0.5 has 19 decimal places.
+	y := NewDecimalAmount(111_111_111_111_111_111, 18)
+	assert.Equal(t, "0.055555555555555556", y.Mul(NewDecimalAmount(5, 1), RoundHalfAwayFromZero).String())
+	assert.Equal(t, "0.055555555555555555", y.Mul(NewDecimalAmount(5, 1), RoundDown).String())
 
 	// Overflow yields ±Inf by the product sign.
 	assert.True(t, NewDecimalAmount(maxDecimalAmountCoefficient, 0).Mul(NewDecimalAmount(maxDecimalAmountCoefficient, 0), RoundHalfAwayFromZero).IsInf(1))
@@ -346,51 +422,66 @@ func TestDecimalAmount_Div(t *testing.T) {
 		a, b DecimalAmount
 		want string
 	}{
-		{NewDecimalAmount(1000, 2), NewDecimalAmount(400, 2), "2.50"}, // 10.00 / 4.00
-		{NewDecimalAmount(1000, 2), NewDecimalAmount(3, 0), "3.33"},   // 10.00 / 3
-		{NewDecimalAmount(10, 0), NewDecimalAmount(3, 0), "3"},        // 10 / 3 -> 3 at scale 0
-		{NewDecimalAmount(1000, 3), NewDecimalAmount(8, 0), "0.125"},  // 1.000 / 8
-		{NewDecimalAmount(-1000, 2), NewDecimalAmount(3, 0), "-3.33"}, // -10.00 / 3
+		// Terminating quotients are exact, with trailing zeros stripped down
+		// to (at least) the preferred scale a.Scale()-b.Scale().
+		{NewDecimalAmount(1000, 2), NewDecimalAmount(400, 2), "2.5"},           // 10.00 / 4.00
+		{NewDecimalAmount(1000, 2), NewDecimalAmount(500, 2), "2"},             // 10.00 / 5.00
+		{NewDecimalAmount(1000, 2), NewDecimalAmount(5, 0), "2.00"},            // 10.00 / 5 keeps the preferred 2 decimals
+		{NewDecimalAmount(1000, 3), NewDecimalAmount(8, 0), "0.125"},           // 1.000 / 8
+		{NewDecimalAmount(100, 2), NewDecimalAmount(8, 0), "0.125"},            // 1.00 / 8 extends beyond the preferred scale
+		{NewDecimalAmount(1, 0), NewDecimalAmount(3, 5), "33333.333333333333"}, // 1 / 0.00003
+		// Non-terminating quotients are rounded at the largest representable scale.
+		{NewDecimalAmount(1000, 2), NewDecimalAmount(3, 0), "3.3333333333333333"},   // 10.00 / 3
+		{NewDecimalAmount(10, 0), NewDecimalAmount(3, 0), "3.3333333333333333"},     // 10 / 3
+		{NewDecimalAmount(-1000, 2), NewDecimalAmount(3, 0), "-3.3333333333333333"}, // -10.00 / 3
 	}
 	for _, c := range cases {
 		got := c.a.Div(c.b, RoundHalfAwayFromZero)
 		assert.Equal(t, c.want, got.String(), "%s / %s", c.a, c.b)
-		assert.Equal(t, c.a.Scale(), got.Scale())
 	}
 
 	// Division by zero yields ±Inf, and 0/0 yields NaN.
 	assert.True(t, NewDecimalAmount(1, 0).Div(NewDecimalAmount(0, 2), RoundHalfAwayFromZero).IsInf(1))
 	assert.True(t, NewDecimalAmount(-1, 0).Div(NewDecimalAmount(0, 2), RoundHalfAwayFromZero).IsInf(-1))
 	assert.True(t, NewDecimalAmount(0, 0).Div(NewDecimalAmount(0, 2), RoundHalfAwayFromZero).IsNaN())
+
+	// A quotient whose integer part overflows the coefficient range yields ±Inf.
+	huge := NewDecimalAmount(maxDecimalAmountCoefficient, 0)
+	tiny := NewDecimalAmount(1, 18)
+	assert.True(t, huge.Div(tiny, RoundHalfAwayFromZero).IsInf(1))
+	assert.True(t, huge.Neg().Div(tiny, RoundHalfAwayFromZero).IsInf(-1))
 }
 
 func TestDecimalAmount_MulDivRoundingModes(t *testing.T) {
-	// 1 / 3 at scale 2: exact 0.3333..., not a tie -> all near modes give 0.33.
-	third := NewDecimalAmount(100, 2).Div(NewDecimalAmount(3, 0), RoundDown)
-	assert.Equal(t, "0.33", third.String())
-	assert.Equal(t, "0.34", NewDecimalAmount(100, 2).Div(NewDecimalAmount(3, 0), RoundUp).String())
+	// Mul and Div round only when the exact result needs more precision than
+	// representable. 1/3 fills all 17 significant digits, so the mode decides
+	// the last digit.
+	assert.Equal(t, "0.33333333333333333", NewDecimalAmount(100, 2).Div(NewDecimalAmount(3, 0), RoundDown).String())
+	assert.Equal(t, "0.33333333333333334", NewDecimalAmount(100, 2).Div(NewDecimalAmount(3, 0), RoundUp).String())
 
-	// Exact ties at scale 1: 0.05 and 0.15 via division by 2 exercise tie modes.
-	// 0.1 / 2 = 0.05 -> tie at scale 1.
-	tie := func(dividend int64, mode RoundingMode) string {
-		return NewDecimalAmount(dividend, 1).Div(NewDecimalAmount(2, 0), mode).String()
+	// 0.111111111111111111 / 2 = 0.0555555555555555555 needs 19 decimal
+	// places, one more than representable, so the dropped digit 5 is an exact
+	// tie. The truncated quotient ...555 is odd, so RoundHalfToEven rounds up.
+	tie := func(sign int64, mode RoundingMode) string {
+		return NewDecimalAmount(sign*111_111_111_111_111_111, 18).
+			Div(NewDecimalAmount(2, 0), mode).String()
 	}
-	// 0.1/2 = 0.05, quotient before rounding = 0 (even); 0.3/2 = 0.15, quotient = 1 (odd).
-	assert.Equal(t, "0.1", tie(1, RoundHalfAwayFromZero)) // 0.05 -> 0.1
-	assert.Equal(t, "0.0", tie(1, RoundHalfToEven))       // 0.05 -> 0.0 (even)
-	assert.Equal(t, "0.2", tie(3, RoundHalfToEven))       // 0.15 -> 0.2 (even)
-	assert.Equal(t, "0.1", tie(1, RoundHalfUp))           // ties toward +Inf
-	assert.Equal(t, "0.0", tie(1, RoundHalfDown))         // ties toward -Inf
-	assert.Equal(t, "0.0", tie(-1, RoundHalfUp))          // -0.05 tie toward +Inf -> 0.0
-	assert.Equal(t, "-0.1", tie(-1, RoundHalfDown))       // -0.05 tie toward -Inf -> -0.1
+	const down, up = "0.055555555555555555", "0.055555555555555556"
+	assert.Equal(t, up, tie(1, RoundHalfAwayFromZero))
+	assert.Equal(t, up, tie(1, RoundHalfToEven)) // odd quotient rounds up to even
+	assert.Equal(t, up, tie(1, RoundHalfUp))     // ties toward +Inf
+	assert.Equal(t, down, tie(1, RoundHalfDown)) // ties toward -Inf
+	assert.Equal(t, "-"+down, tie(-1, RoundHalfUp))
+	assert.Equal(t, "-"+up, tie(-1, RoundHalfDown))
+	assert.Equal(t, "-"+up, tie(-1, RoundHalfAwayFromZero))
 
-	// Directed modes on 0.05.
-	assert.Equal(t, "0.0", tie(1, RoundFloor))
-	assert.Equal(t, "0.1", tie(1, RoundCeil))
-	assert.Equal(t, "-0.1", tie(-1, RoundFloor))
-	assert.Equal(t, "0.0", tie(-1, RoundCeil))
-	assert.Equal(t, "0.0", tie(1, RoundDown))
-	assert.Equal(t, "0.1", tie(1, RoundUp))
+	// Directed modes.
+	assert.Equal(t, down, tie(1, RoundFloor))
+	assert.Equal(t, up, tie(1, RoundCeil))
+	assert.Equal(t, "-"+up, tie(-1, RoundFloor))
+	assert.Equal(t, "-"+down, tie(-1, RoundCeil))
+	assert.Equal(t, down, tie(1, RoundDown))
+	assert.Equal(t, up, tie(1, RoundUp))
 
 	assert.Equal(t, "RoundHalfToEven", RoundHalfToEven.String())
 }
@@ -530,7 +621,7 @@ func TestDecimalAmount_SQL(t *testing.T) {
 
 func TestNullableDecimalAmount(t *testing.T) {
 	// Non-null round-trips through JSON as a number.
-	n := NullableDecimalAmountFrom(NewDecimalAmount(123456, 2))
+	n := NewDecimalAmount(123456, 2).Nullable()
 	data, err := json.Marshal(n)
 	require.NoError(t, err)
 	assert.Equal(t, "1234.56", string(data))
@@ -567,21 +658,33 @@ func TestDecimalAmount_ScanString(t *testing.T) {
 	assert.Error(t, a.ScanString("not a number", false))
 }
 
-func TestDecimalAmountFromFloat(t *testing.T) {
-	a, err := DecimalAmountFromFloat(1234.567, 2, RoundHalfAwayFromZero)
-	require.NoError(t, err)
-	assert.Equal(t, "1234.57", a.String())
+func TestDecimalAmountFrom(t *testing.T) {
+	// Integers convert exactly with scale 0.
+	assert.Equal(t, NewDecimalAmount(42, 0), DecimalAmountFrom(42))
+	assert.Equal(t, NewDecimalAmount(-42, 0), DecimalAmountFrom(int8(-42)))
+	assert.Equal(t, NewDecimalAmount(65535, 0), DecimalAmountFrom(uint16(65535)))
+	assert.Equal(t, NewDecimalAmount(maxDecimalAmountCoefficient, 0), DecimalAmountFrom(int64(maxDecimalAmountCoefficient)))
+	// An integer outside the coefficient range maps to ±Inf instead of panicking.
+	assert.True(t, DecimalAmountFrom(int64(math.MaxInt64)).IsInf(1))
+	assert.True(t, DecimalAmountFrom(int64(math.MinInt64)).IsInf(-1))
+	assert.True(t, DecimalAmountFrom(uint64(math.MaxUint64)).IsInf(1))
 
-	// Exact float value is rounded per mode: 0.5 is exactly representable.
-	half, err := DecimalAmountFromFloat(0.5, 0, RoundHalfToEven)
-	require.NoError(t, err)
-	assert.Equal(t, "0", half.String()) // 0.5 -> 0 (even)
-	half, err = DecimalAmountFromFloat(0.5, 0, RoundHalfAwayFromZero)
-	require.NoError(t, err)
-	assert.Equal(t, "1", half.String())
-
-	_, err = DecimalAmountFromFloat(1, MaxDecimalAmountScale+1, RoundHalfAwayFromZero)
-	assert.Error(t, err)
+	// Floats convert via their shortest round-tripping decimal representation.
+	assert.Equal(t, "1234.567", DecimalAmountFrom(1234.567).String())
+	assert.Equal(t, "0.1", DecimalAmountFrom(0.1).String())
+	assert.Equal(t, "0.5", DecimalAmountFrom(0.5).String())
+	// float32 uses the float32 shortest representation, not the float64 one.
+	assert.Equal(t, "0.1", DecimalAmountFrom(float32(0.1)).String())
+	// Amount and Rate convert like float64.
+	assert.Equal(t, "1234.56", DecimalAmountFrom(Amount(1234.56)).String())
+	assert.Equal(t, "1.19", DecimalAmountFrom(Rate(1.19)).String())
+	// Non-finite floats map to the sentinels.
+	assert.True(t, DecimalAmountFrom(math.NaN()).IsNaN())
+	assert.True(t, DecimalAmountFrom(math.Inf(-1)).IsInf(-1))
+	// A float needing more than 18 fractional digits is rounded at scale 18.
+	assert.True(t, DecimalAmountFrom(1e-19).IsZero())
+	// A float too large for the coefficient range maps to +Inf.
+	assert.True(t, DecimalAmountFrom(1e30).IsInf(1))
 }
 
 // TestDecimalAmount_MarshalJSONValidNumber guards that MarshalJSON always emits
@@ -613,9 +716,9 @@ func TestDecimalAmount_nonFiniteNoPanic(t *testing.T) {
 	assert.True(t, math.IsInf(float64(CurrencyDecimalAmountEUR(posInf).CurrencyAmount().Amount), 1))
 
 	// Rate methods on a non-finite receiver propagate instead of panicking.
-	assert.True(t, posInf.MultipliedByRate(Rate(2), 2, RoundHalfAwayFromZero).IsInf(1))
-	assert.True(t, negInf.DividedByRate(Rate(2), 2, RoundHalfAwayFromZero).IsInf(-1))
-	assert.True(t, nan.Percentage(50, 2, RoundHalfAwayFromZero).IsNaN())
+	assert.True(t, posInf.MultipliedByRate(Rate(2)).IsInf(1))
+	assert.True(t, negInf.DividedByRate(Rate(2)).IsInf(-1))
+	assert.True(t, nan.Percentage(50).IsNaN())
 
 	// fmt: non-finite tokens are space-padded (never zero-padded) and honor the
 	// sign flag on +Inf, matching the standard library.
@@ -696,10 +799,10 @@ func TestDecimalAmount_FromFloatOracle(t *testing.T) {
 		for scale := 0; scale <= MaxDecimalAmountScale; scale++ {
 			for _, mode := range modes {
 				want := floatToDecimalOracle(f, scale, mode)
-				got, err := DecimalAmountFromFloat(f, scale, mode)
+				got, err := decimalFromFloatRounded(f, scale, mode)
 				require.NoError(t, err)
 				if want != got {
-					t.Fatalf("FromFloat(%v, %d, %s) = %s (packed %d), want %s (packed %d)",
+					t.Fatalf("fromFloat(%v, %d, %s) = %s (packed %d), want %s (packed %d)",
 						f, scale, mode, got, got, want, want)
 				}
 			}
@@ -832,7 +935,7 @@ func TestDecimalAmount_sentinels(t *testing.T) {
 }
 
 func TestDecimalAmount_accessors(t *testing.T) {
-	assert.Equal(t, "42", DecimalAmountFromInt(42).String())
+	assert.Equal(t, "42", DecimalAmountFrom(42).String())
 
 	pos := NewDecimalAmount(150, 2)
 	neg := NewDecimalAmount(-150, 2)
@@ -862,34 +965,41 @@ func TestDecimalAmount_AmountInterop(t *testing.T) {
 	d := NewDecimalAmount(123456, 2)
 	assert.InDelta(t, 1234.56, float64(d.Amount()), 1e-9)
 
-	got, err := DecimalAmountFromAmount(Amount(1234.567), 2, RoundHalfAwayFromZero)
-	require.NoError(t, err)
+	// DecimalAmountFrom converts an Amount via its shortest exact decimal;
+	// round explicitly for a fixed scale.
+	got := DecimalAmountFrom(Amount(1234.567)).RoundToDecimals(2, RoundHalfAwayFromZero)
 	assert.Equal(t, "1234.57", got.String())
 
-	// Amount.DecimalAmount method mirror.
+	// Amount.DecimalAmount rounds the exact binary float64 value directly.
 	assert.Equal(t, "1234.57", Amount(1234.567).DecimalAmount(2, RoundHalfAwayFromZero).String())
 	// A non-finite Amount maps to the matching sentinel instead of panicking.
 	assert.True(t, Amount(math.Inf(1)).DecimalAmount(2, RoundHalfAwayFromZero).IsInf(1))
 	assert.True(t, Amount(math.NaN()).DecimalAmount(2, RoundHalfAwayFromZero).IsNaN())
 
-	// Round-trip Amount -> DecimalAmount -> Amount at 2 decimals.
-	back, err := DecimalAmountFromAmount(d.Amount(), 2, RoundHalfAwayFromZero)
-	require.NoError(t, err)
+	// Round-trip Amount -> DecimalAmount -> Amount.
+	back := DecimalAmountFrom(d.Amount())
 	assert.True(t, d.Equal(back))
 }
 
 func TestDecimalAmount_RateInterop(t *testing.T) {
 	price := NewDecimalAmount(10000, 2) // 100.00
 
-	// 100.00 * 1.19 VAT rate -> 119.00 at 2 decimals.
-	assert.Equal(t, "119.00", price.MultipliedByRate(Rate(1.19), 2, RoundHalfAwayFromZero).String())
-	// Reverse: 119.00 / 1.19 -> 100.00.
-	assert.Equal(t, "100.00", NewDecimalAmount(11900, 2).DividedByRate(Rate(1.19), 2, RoundHalfAwayFromZero).String())
-	// 19% of 100.00 -> 19.00.
-	assert.Equal(t, "19.00", price.Percentage(19, 2, RoundHalfAwayFromZero).String())
-	// Result scale is the requested one.
-	assert.Equal(t, 4, price.MultipliedByRate(Rate(1.19), 4, RoundHalfAwayFromZero).Scale())
+	// The result is the shortest decimal that round-trips the float64
+	// product exactly; round to the final precision explicitly at the end.
+	product := price.MultipliedByRate(Rate(1.19))
+	assert.Equal(t, "119.00", product.RoundToCents(RoundHalfAwayFromZero).String())
+	// A float64 product carrying binary noise keeps that noise until rounded:
+	// 0.10 * 3 in float64 is 0.30000000000000004.
+	noisy := NewDecimalAmount(10, 2).MultipliedByRate(Rate(3))
+	assert.Equal(t, "0.30000000000000004", noisy.String())
+	assert.Equal(t, "0.30", noisy.RoundToCents(RoundHalfAwayFromZero).String())
+	// Reverse: 119.00 / 1.19 -> 100.00 after rounding to cents.
+	assert.Equal(t, "100.00", NewDecimalAmount(11900, 2).DividedByRate(Rate(1.19)).RoundToCents(RoundHalfAwayFromZero).String())
+	// 19% of 100.00 -> 19.00 (exact in float64, shortest representation "19").
+	assert.Equal(t, "19.00", price.Percentage(19).RoundToCents(RoundHalfAwayFromZero).String())
+	// An exact float64 product converts without any rounding needed.
+	assert.Equal(t, "250", price.MultipliedByRate(Rate(2.5)).String())
 
 	// Dividing by a zero rate yields +Inf instead of panicking.
-	assert.True(t, price.DividedByRate(Rate(0), 2, RoundHalfAwayFromZero).IsInf(1))
+	assert.True(t, price.DividedByRate(Rate(0)).IsInf(1))
 }

--- a/money/decimalamount_test.go
+++ b/money/decimalamount_test.go
@@ -150,6 +150,28 @@ func TestDecimalAmount_String(t *testing.T) {
 func TestDecimalAmount_GoString(t *testing.T) {
 	assert.Equal(t, "money.NewDecimalAmount(123456, 2)", NewDecimalAmount(123456, 2).GoString())
 	assert.Equal(t, "money.NewDecimalAmount(123456, 2)", fmt.Sprintf("%#v", NewDecimalAmount(123456, 2)))
+	// Non-finite sentinels produce constructor-call source (round-trips as Go).
+	assert.Equal(t, "money.DecimalAmountNaN()", DecimalAmountNaN().GoString())
+	assert.Equal(t, "money.DecimalAmountInf(-1)", DecimalAmountInf(-1).GoString())
+}
+
+func TestRoundingMode_String(t *testing.T) {
+	// Every mode has a distinct name and an unknown mode is reported by value;
+	// the strings match the constant identifiers so they are safe to log/parse.
+	cases := map[RoundingMode]string{
+		RoundHalfAwayFromZero: "RoundHalfAwayFromZero",
+		RoundHalfToEven:       "RoundHalfToEven",
+		RoundHalfUp:           "RoundHalfUp",
+		RoundHalfDown:         "RoundHalfDown",
+		RoundDown:             "RoundDown",
+		RoundUp:               "RoundUp",
+		RoundFloor:            "RoundFloor",
+		RoundCeil:             "RoundCeil",
+	}
+	for mode, want := range cases {
+		assert.Equal(t, want, mode.String())
+	}
+	assert.Equal(t, "Unknown rounding mode: 99", RoundingMode(99).String())
 }
 
 func TestDecimalAmount_FormatSep(t *testing.T) {
@@ -204,6 +226,9 @@ func TestDecimalAmount_CmpEqual(t *testing.T) {
 	assert.Equal(t, -1, NewDecimalAmount(149, 2).Cmp(b))
 	assert.Equal(t, +1, NewDecimalAmount(151, 2).Cmp(b))
 	assert.Equal(t, -1, NewDecimalAmount(-1, 0).Cmp(NewDecimalAmount(1, 0)))
+	// Equal scale, differing coefficients exercise both fast-path branches.
+	assert.Equal(t, +1, NewDecimalAmount(200, 2).Cmp(NewDecimalAmount(100, 2)))
+	assert.Equal(t, -1, NewDecimalAmount(100, 2).Cmp(NewDecimalAmount(200, 2)))
 	// Large cross-scale comparison must not overflow.
 	assert.Equal(t, +1, NewDecimalAmount(maxDecimalAmountCoefficient, 0).Cmp(NewDecimalAmount(1, 18)))
 }
@@ -535,9 +560,23 @@ func TestDecimalAmount_JSON(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(`"1234.56"`), &got))
 	assert.Equal(t, "1234.56", got.String())
 
+	// A quoted string carrying JSON escape sequences must be decoded through
+	// the standard library, not by stripping the outer quotes. The token here
+	// spells the digit 1 as a Unicode escape (u+0031); a conformant encoder
+	// may emit that and it must still decode to 1.23. byte(92) is the
+	// backslash, written numerically so the source carries no literal escape.
+	got = DecimalAmount{}
+	escaped := string([]byte{'"', byte(92), 'u', '0', '0', '3', '1', '.', '2', '3', '"'})
+	require.NoError(t, json.Unmarshal([]byte(escaped), &got))
+	assert.Equal(t, "1.23", got.String())
+
 	// null and "" decode to zero.
 	got = NewDecimalAmount(1, 0)
 	require.NoError(t, json.Unmarshal([]byte("null"), &got))
+	assert.True(t, got.IsZero())
+
+	got = NewDecimalAmount(1, 0)
+	require.NoError(t, json.Unmarshal([]byte(`""`), &got))
 	assert.True(t, got.IsZero())
 
 	// Round-trip inside a struct.
@@ -617,6 +656,9 @@ func TestDecimalAmount_SQL(t *testing.T) {
 
 	var got DecimalAmount
 	assert.Error(t, got.Scan(true))
+	// An int64 outside the coefficient range is rejected rather than silently
+	// truncated (the coefficient must round-trip Neg/Abs).
+	assert.Error(t, got.Scan(int64(math.MaxInt64)))
 }
 
 func TestNullableDecimalAmount(t *testing.T) {

--- a/money/decimalamount_test.go
+++ b/money/decimalamount_test.go
@@ -1,0 +1,688 @@
+package money
+
+import (
+	"bytes"
+	"database/sql/driver"
+	"encoding/json"
+	"fmt"
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecimalAmount_packing(t *testing.T) {
+	cases := []struct {
+		coeff int64
+		scale int
+	}{
+		{0, 0},
+		{123456, 2},
+		{-123456, 2},
+		{1, 18},
+		{-1, 18},
+		{maxDecimalAmountCoefficient, 0},
+		{minDecimalAmountCoefficient, 0},
+		{maxDecimalAmountCoefficient, 18},
+		{minDecimalAmountCoefficient, 18},
+	}
+	for _, c := range cases {
+		a := NewDecimalAmount(c.coeff, c.scale)
+		assert.Equal(t, c.coeff, a.Coefficient(), "coefficient for %d/%d", c.coeff, c.scale)
+		assert.Equal(t, c.scale, a.Scale(), "scale for %d/%d", c.coeff, c.scale)
+	}
+}
+
+func TestDecimalAmount_zeroValue(t *testing.T) {
+	var a DecimalAmount
+	assert.Equal(t, int64(0), a.Coefficient())
+	assert.Equal(t, 0, a.Scale())
+	assert.True(t, a.IsZero())
+	assert.Equal(t, "0", a.String())
+}
+
+func TestNewDecimalAmount_panics(t *testing.T) {
+	assert.Panics(t, func() { NewDecimalAmount(1, -1) })
+	assert.Panics(t, func() { NewDecimalAmount(1, MaxDecimalAmountScale+1) })
+	assert.Panics(t, func() { NewDecimalAmount(maxDecimalAmountCoefficient+1, 0) })
+	assert.Panics(t, func() { NewDecimalAmount(minDecimalAmountCoefficient-1, 0) })
+}
+
+func TestParseDecimalAmount(t *testing.T) {
+	cases := []struct {
+		str   string
+		coeff int64
+		scale int
+	}{
+		{"0", 0, 0},
+		{"1234", 1234, 0},
+		{"1234.56", 123456, 2},
+		{"-99.99", -9999, 2},
+		{"0.005", 5, 3},
+		{"-0.005", -5, 3},
+		{"007.50", 750, 2},
+		{"1,234.56", 123456, 2}, // English grouping
+		{"1.234,56", 123456, 2}, // German grouping
+		{"1'234.56", 123456, 2}, // Swiss grouping
+		{"1,234,567.89", 123456789, 2},
+		{"-0.00", 0, 2},
+		// Exactness: this loses its last cent through a float64 round-trip
+		// but must be preserved here.
+		{"99999999999999.99", 9999999999999999, 2},
+	}
+	for _, c := range cases {
+		a, err := ParseDecimalAmount(c.str)
+		require.NoError(t, err, "ParseDecimalAmount(%q)", c.str)
+		assert.Equal(t, c.coeff, a.Coefficient(), "coefficient of %q", c.str)
+		assert.Equal(t, c.scale, a.Scale(), "scale of %q", c.str)
+	}
+}
+
+func TestParseDecimalAmount_exactBeatsFloat(t *testing.T) {
+	const s = "99999999999999.99"
+	a, err := ParseDecimalAmount(s)
+	require.NoError(t, err)
+	assert.Equal(t, s, a.String())
+
+	// The float64 path used by the plain Amount type loses the last cent.
+	f, err := ParseAmount(s)
+	require.NoError(t, err)
+	assert.NotEqual(t, s, f.String())
+}
+
+func TestParseDecimalAmount_acceptedDecimals(t *testing.T) {
+	_, err := ParseDecimalAmount("1.234", 0, 2)
+	assert.Error(t, err, "3 decimals not in {0,2}")
+
+	a, err := ParseDecimalAmount("1.23", 0, 2)
+	require.NoError(t, err)
+	assert.Equal(t, "1.23", a.String())
+}
+
+func TestParseDecimalAmount_errors(t *testing.T) {
+	for _, s := range []string{
+		"",
+		"1.5e3",                 // scientific notation rejected
+		"1.1234567890123456789", // 19 decimals > MaxDecimalAmountScale
+		"999999999999999999",    // 18 nines ~1e18 exceeds coefficient range
+		"abc",
+	} {
+		_, err := ParseDecimalAmount(s)
+		assert.Error(t, err, "expected error parsing %q", s)
+	}
+}
+
+func TestParseDecimalAmount_nonFinite(t *testing.T) {
+	for _, s := range []string{"NaN"} {
+		a, err := ParseDecimalAmount(s)
+		require.NoError(t, err)
+		assert.True(t, a.IsNaN(), "%q should parse to NaN", s)
+	}
+	for _, s := range []string{"Inf", "+Inf"} {
+		a, err := ParseDecimalAmount(s)
+		require.NoError(t, err)
+		assert.True(t, a.IsInf(1), "%q should parse to +Inf", s)
+	}
+	a, err := ParseDecimalAmount("-Inf")
+	require.NoError(t, err)
+	assert.True(t, a.IsInf(-1))
+}
+
+func TestDecimalAmount_String(t *testing.T) {
+	cases := map[string]DecimalAmount{
+		"0":        NewDecimalAmount(0, 0),
+		"0.00":     NewDecimalAmount(0, 2),
+		"1234.56":  NewDecimalAmount(123456, 2),
+		"-1234.56": NewDecimalAmount(-123456, 2),
+		"0.005":    NewDecimalAmount(5, 3),
+		"-0.005":   NewDecimalAmount(-5, 3),
+		"1.50":     NewDecimalAmount(150, 2),
+		"1000":     NewDecimalAmount(1000, 0),
+	}
+	for want, a := range cases {
+		assert.Equal(t, want, a.String(), "String of coeff=%d scale=%d", a.Coefficient(), a.Scale())
+	}
+}
+
+func TestDecimalAmount_GoString(t *testing.T) {
+	assert.Equal(t, "money.NewDecimalAmount(123456, 2)", NewDecimalAmount(123456, 2).GoString())
+	assert.Equal(t, "money.NewDecimalAmount(123456, 2)", fmt.Sprintf("%#v", NewDecimalAmount(123456, 2)))
+}
+
+func TestDecimalAmount_FormatSep(t *testing.T) {
+	a := NewDecimalAmount(123456789, 2) // 1234567.89
+	assert.Equal(t, "1234567.89", a.FormatSep(0, '.'))
+	assert.Equal(t, "1,234,567.89", a.FormatSep(',', '.'))
+	assert.Equal(t, "1.234.567,89", a.FormatSep('.', ','))
+	assert.Equal(t, "-1.234.567,89", a.Neg().FormatSep('.', ','))
+	// zero decimalSep defaults to '.'
+	assert.Equal(t, "1,234,567.89", a.FormatSep(',', 0))
+}
+
+func TestDecimalAmount_Format(t *testing.T) {
+	a := NewDecimalAmount(123456, 2) // 1234.56
+	cases := map[string]string{
+		"%s":     "1234.56",
+		"%v":     "1234.56",
+		"%q":     `"1234.56"`,
+		"%f":     "1234.56",   // default precision = scale
+		"%.1f":   "1234.6",    // rounds half away from zero
+		"%.4f":   "1234.5600", // pads
+		"%.0f":   "1235",
+		"%d":     "1235",
+		"%#f":    "1,234.56", // grouping
+		"%#d":    "1,235",
+		"%+.2f":  "+1234.56",
+		"% .2f":  " 1234.56",
+		"%8.1f":  "  1234.6", // width padding
+		"%-8.1f": "1234.6  ",
+		"%08.1f": "001234.6",
+	}
+	for format, want := range cases {
+		assert.Equal(t, want, fmt.Sprintf(format, a), "format %q", format)
+	}
+	// Negative zero-padding keeps the sign leftmost.
+	assert.Equal(t, "-01234.6", fmt.Sprintf("%08.1f", a.Neg()))
+	// Unknown verb reports the type.
+	assert.Equal(t, "%!x(money.DecimalAmount=1234.56)", fmt.Sprintf("%x", a))
+	// Formatting must not panic even for the largest value at high precision.
+	big := NewDecimalAmount(maxDecimalAmountCoefficient, 0)
+	assert.NotPanics(t, func() { _ = fmt.Sprintf("%.18f", big) })
+}
+
+func TestDecimalAmount_CmpEqual(t *testing.T) {
+	// Same value, different scale.
+	a := NewDecimalAmount(150, 2) // 1.50
+	b := NewDecimalAmount(15, 1)  // 1.5
+	assert.NotEqual(t, a, b, "different packed representation")
+	assert.True(t, a.Equal(b), "equal value")
+	assert.Equal(t, 0, a.Cmp(b))
+
+	assert.Equal(t, -1, NewDecimalAmount(149, 2).Cmp(b))
+	assert.Equal(t, +1, NewDecimalAmount(151, 2).Cmp(b))
+	assert.Equal(t, -1, NewDecimalAmount(-1, 0).Cmp(NewDecimalAmount(1, 0)))
+	// Large cross-scale comparison must not overflow.
+	assert.Equal(t, +1, NewDecimalAmount(maxDecimalAmountCoefficient, 0).Cmp(NewDecimalAmount(1, 18)))
+}
+
+func TestDecimalAmount_AddSub(t *testing.T) {
+	a := NewDecimalAmount(123, 2)  // 1.23
+	b := NewDecimalAmount(4567, 4) // 0.4567
+	sum := a.Add(b)
+	assert.Equal(t, "1.6867", sum.String())
+	assert.Equal(t, 4, sum.Scale())
+
+	diff := a.Sub(b)
+	assert.Equal(t, "0.7733", diff.String())
+
+	// Adding opposite values yields zero at the larger scale.
+	z := NewDecimalAmount(5, 2).Add(NewDecimalAmount(-5, 2))
+	assert.True(t, z.IsZero())
+
+	// Overflow yields +Inf (or -Inf for negative operands).
+	assert.True(t, NewDecimalAmount(maxDecimalAmountCoefficient, 0).Add(NewDecimalAmount(maxDecimalAmountCoefficient, 0)).IsInf(1))
+	assert.True(t, NewDecimalAmount(minDecimalAmountCoefficient, 0).Add(NewDecimalAmount(minDecimalAmountCoefficient, 0)).IsInf(-1))
+}
+
+func TestDecimalAmount_MulInt(t *testing.T) {
+	a := NewDecimalAmount(199, 2) // 1.99
+	assert.Equal(t, "5.97", a.MulInt(3).String())
+	assert.Equal(t, "-3.98", a.MulInt(-2).String())
+	assert.Equal(t, "0.00", a.MulInt(0).String())
+	assert.True(t, NewDecimalAmount(maxDecimalAmountCoefficient, 0).MulInt(2).IsInf(1))
+
+	// MulInt64 takes the wider int64 and MulInt delegates to it.
+	assert.Equal(t, "5.97", a.MulInt64(3).String())
+	assert.Equal(t, a.MulInt(3), a.MulInt64(3))
+	assert.True(t, NewDecimalAmount(maxDecimalAmountCoefficient, 0).MulInt64(2).IsInf(1))
+	assert.True(t, NewDecimalAmount(minDecimalAmountCoefficient, 0).MulInt(2).IsInf(-1))
+}
+
+func TestDecimalAmount_Mul(t *testing.T) {
+	cases := []struct {
+		a, b DecimalAmount
+		want string
+	}{
+		// Result takes the scale of a.
+		{NewDecimalAmount(150, 2), NewDecimalAmount(150, 2), "2.25"}, // 1.50 * 1.50
+		{NewDecimalAmount(10, 1), NewDecimalAmount(10, 1), "1.0"},    // 1.0 * 1.0
+		{NewDecimalAmount(3, 0), NewDecimalAmount(4, 0), "12"},       // 3 * 4
+		{NewDecimalAmount(-2, 0), NewDecimalAmount(150, 2), "-3"},    // -2 * 1.50 -> -3.00 at scale 0
+		{NewDecimalAmount(100, 2), NewDecimalAmount(119, 2), "1.19"}, // 1.00 * 1.19
+		// Rounding to a's scale, half away from zero.
+		{NewDecimalAmount(11, 1), NewDecimalAmount(11, 1), "1.2"}, // 1.1 * 1.1 = 1.21 -> 1.2
+	}
+	for _, c := range cases {
+		got := c.a.Mul(c.b, RoundHalfAwayFromZero)
+		assert.Equal(t, c.want, got.String(), "%s * %s", c.a, c.b)
+		assert.Equal(t, c.a.Scale(), got.Scale())
+	}
+
+	// Large product whose exact 128-bit intermediate exceeds 64 bits:
+	// 5.000000000 * 5.000000000 = 25.000000000 (product 2.5e19 needs 65 bits).
+	x := NewDecimalAmount(5_000_000_000, 9)
+	assert.Equal(t, "25.000000000", x.Mul(x, RoundHalfAwayFromZero).String())
+
+	// Overflow yields ±Inf by the product sign.
+	assert.True(t, NewDecimalAmount(maxDecimalAmountCoefficient, 0).Mul(NewDecimalAmount(maxDecimalAmountCoefficient, 0), RoundHalfAwayFromZero).IsInf(1))
+	assert.True(t, NewDecimalAmount(minDecimalAmountCoefficient, 0).Mul(NewDecimalAmount(maxDecimalAmountCoefficient, 0), RoundHalfAwayFromZero).IsInf(-1))
+}
+
+func TestDecimalAmount_Div(t *testing.T) {
+	cases := []struct {
+		a, b DecimalAmount
+		want string
+	}{
+		{NewDecimalAmount(1000, 2), NewDecimalAmount(400, 2), "2.50"}, // 10.00 / 4.00
+		{NewDecimalAmount(1000, 2), NewDecimalAmount(3, 0), "3.33"},   // 10.00 / 3
+		{NewDecimalAmount(10, 0), NewDecimalAmount(3, 0), "3"},        // 10 / 3 -> 3 at scale 0
+		{NewDecimalAmount(1000, 3), NewDecimalAmount(8, 0), "0.125"},  // 1.000 / 8
+		{NewDecimalAmount(-1000, 2), NewDecimalAmount(3, 0), "-3.33"}, // -10.00 / 3
+	}
+	for _, c := range cases {
+		got := c.a.Div(c.b, RoundHalfAwayFromZero)
+		assert.Equal(t, c.want, got.String(), "%s / %s", c.a, c.b)
+		assert.Equal(t, c.a.Scale(), got.Scale())
+	}
+
+	// Division by zero yields ±Inf, and 0/0 yields NaN.
+	assert.True(t, NewDecimalAmount(1, 0).Div(NewDecimalAmount(0, 2), RoundHalfAwayFromZero).IsInf(1))
+	assert.True(t, NewDecimalAmount(-1, 0).Div(NewDecimalAmount(0, 2), RoundHalfAwayFromZero).IsInf(-1))
+	assert.True(t, NewDecimalAmount(0, 0).Div(NewDecimalAmount(0, 2), RoundHalfAwayFromZero).IsNaN())
+}
+
+func TestDecimalAmount_MulDivRoundingModes(t *testing.T) {
+	// 1 / 3 at scale 2: exact 0.3333..., not a tie -> all near modes give 0.33.
+	third := NewDecimalAmount(100, 2).Div(NewDecimalAmount(3, 0), RoundDown)
+	assert.Equal(t, "0.33", third.String())
+	assert.Equal(t, "0.34", NewDecimalAmount(100, 2).Div(NewDecimalAmount(3, 0), RoundUp).String())
+
+	// Exact ties at scale 1: 0.05 and 0.15 via division by 2 exercise tie modes.
+	// 0.1 / 2 = 0.05 -> tie at scale 1.
+	tie := func(dividend int64, mode RoundingMode) string {
+		return NewDecimalAmount(dividend, 1).Div(NewDecimalAmount(2, 0), mode).String()
+	}
+	// 0.1/2 = 0.05, quotient before rounding = 0 (even); 0.3/2 = 0.15, quotient = 1 (odd).
+	assert.Equal(t, "0.1", tie(1, RoundHalfAwayFromZero)) // 0.05 -> 0.1
+	assert.Equal(t, "0.0", tie(1, RoundHalfToEven))       // 0.05 -> 0.0 (even)
+	assert.Equal(t, "0.2", tie(3, RoundHalfToEven))       // 0.15 -> 0.2 (even)
+	assert.Equal(t, "0.1", tie(1, RoundHalfUp))           // ties toward +Inf
+	assert.Equal(t, "0.0", tie(1, RoundHalfDown))         // ties toward -Inf
+	assert.Equal(t, "0.0", tie(-1, RoundHalfUp))          // -0.05 tie toward +Inf -> 0.0
+	assert.Equal(t, "-0.1", tie(-1, RoundHalfDown))       // -0.05 tie toward -Inf -> -0.1
+
+	// Directed modes on 0.05.
+	assert.Equal(t, "0.0", tie(1, RoundFloor))
+	assert.Equal(t, "0.1", tie(1, RoundCeil))
+	assert.Equal(t, "-0.1", tie(-1, RoundFloor))
+	assert.Equal(t, "0.0", tie(-1, RoundCeil))
+	assert.Equal(t, "0.0", tie(1, RoundDown))
+	assert.Equal(t, "0.1", tie(1, RoundUp))
+
+	assert.Equal(t, "RoundHalfToEven", RoundHalfToEven.String())
+}
+
+func TestDecimalAmount_Rounding(t *testing.T) {
+	cases := []struct {
+		in       DecimalAmount
+		decimals int
+		want     string
+	}{
+		{NewDecimalAmount(12345, 3), 2, "12.35"}, // 12.345 -> 12.35 (half away)
+		{NewDecimalAmount(12344, 3), 2, "12.34"},
+		{NewDecimalAmount(-12345, 3), 2, "-12.35"},
+		{NewDecimalAmount(125, 2), 1, "1.3"},    // 1.25 -> 1.3 (half away from zero)
+		{NewDecimalAmount(150, 2), 4, "1.5000"}, // padding
+		{NewDecimalAmount(19, 1), 0, "2"},       // 1.9 -> 2
+		{NewDecimalAmount(-15, 1), 0, "-2"},     // -1.5 -> -2 (half away)
+	}
+	for _, c := range cases {
+		got := c.in.RoundToDecimals(c.decimals, RoundHalfAwayFromZero).String()
+		assert.Equal(t, c.want, got, "%s round to %d", c.in, c.decimals)
+	}
+	assert.Equal(t, "1.25", NewDecimalAmount(12500, 4).RoundToCents(RoundHalfAwayFromZero).String())
+	assert.Equal(t, "2", NewDecimalAmount(150, 2).RoundToInt(RoundHalfAwayFromZero).String())
+
+	// RoundToDecimals honors the rounding mode.
+	assert.Equal(t, "12.34", NewDecimalAmount(12345, 3).RoundToDecimals(2, RoundHalfToEven).String()) // 12.345 -> 12.34 (even)
+	assert.Equal(t, "12.35", NewDecimalAmount(12350, 3).RoundToDecimals(2, RoundUp).String())
+	assert.Equal(t, "12.34", NewDecimalAmount(12345, 3).RoundToDecimals(2, RoundDown).String())
+	assert.Equal(t, "-12.35", NewDecimalAmount(-12341, 3).RoundToDecimals(2, RoundFloor).String())
+}
+
+func TestDecimalAmount_FloatAndAmount(t *testing.T) {
+	a := NewDecimalAmount(123456, 2)
+	assert.InDelta(t, 1234.56, a.Float(), 1e-9)
+	assert.InDelta(t, 1234.56, float64(a.Amount()), 1e-9)
+}
+
+func TestDecimalAmount_JSON(t *testing.T) {
+	a := NewDecimalAmount(123456, 2)
+	data, err := json.Marshal(a)
+	require.NoError(t, err)
+	assert.Equal(t, "1234.56", string(data)) // unquoted number
+
+	var got DecimalAmount
+	require.NoError(t, json.Unmarshal([]byte("1234.56"), &got))
+	assert.True(t, a.Equal(got))
+
+	// Accept quoted string too.
+	got = DecimalAmount{}
+	require.NoError(t, json.Unmarshal([]byte(`"1234.56"`), &got))
+	assert.Equal(t, "1234.56", got.String())
+
+	// null and "" decode to zero.
+	got = NewDecimalAmount(1, 0)
+	require.NoError(t, json.Unmarshal([]byte("null"), &got))
+	assert.True(t, got.IsZero())
+
+	// Round-trip inside a struct.
+	type wrap struct {
+		Price DecimalAmount `json:"price"`
+	}
+	b, err := json.Marshal(wrap{Price: NewDecimalAmount(99999, 2)})
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"price":999.99}`, string(b))
+}
+
+func TestDecimalAmount_Text(t *testing.T) {
+	a := NewDecimalAmount(-5, 3)
+	text, err := a.MarshalText()
+	require.NoError(t, err)
+	assert.Equal(t, "-0.005", string(text))
+
+	var got DecimalAmount
+	require.NoError(t, got.UnmarshalText(text))
+	assert.Equal(t, a, got)
+
+	got = NewDecimalAmount(1, 0)
+	require.NoError(t, got.UnmarshalText(nil))
+	assert.True(t, got.IsZero())
+}
+
+func TestDecimalAmount_Binary(t *testing.T) {
+	for _, a := range []DecimalAmount{
+		NewDecimalAmount(0, 0),
+		NewDecimalAmount(123456, 2),
+		NewDecimalAmount(-123456, 2),
+		NewDecimalAmount(maxDecimalAmountCoefficient, 18),
+		NewDecimalAmount(minDecimalAmountCoefficient, 18),
+	} {
+		data, err := a.MarshalBinary()
+		require.NoError(t, err)
+		assert.Len(t, data, 8)
+
+		var got DecimalAmount
+		require.NoError(t, got.UnmarshalBinary(data))
+		assert.Equal(t, a, got, "binary round-trip of %s", a)
+	}
+
+	var got DecimalAmount
+	assert.Error(t, got.UnmarshalBinary([]byte{1, 2, 3}))
+	// A scale > MaxDecimalAmountScale in the low bits must be rejected.
+	bad := make([]byte, 8)
+	bad[7] = 19
+	assert.Error(t, got.UnmarshalBinary(bad))
+}
+
+func TestDecimalAmount_SQL(t *testing.T) {
+	a := NewDecimalAmount(123456, 2)
+	v, err := a.Value()
+	require.NoError(t, err)
+	assert.Equal(t, "1234.56", v)
+	assert.IsType(t, driver.Value(""), v)
+
+	cases := []struct {
+		src  any
+		want string
+	}{
+		{"1234.56", "1234.56"},
+		{[]byte("1.234,56"), "1234.56"},
+		{int64(42), "42"},
+		{float64(12.5), "12.5"},
+	}
+	for _, c := range cases {
+		var got DecimalAmount
+		require.NoError(t, got.Scan(c.src), "scan %#v", c.src)
+		assert.Equal(t, c.want, got.String(), "scan %#v", c.src)
+	}
+
+	var got DecimalAmount
+	assert.Error(t, got.Scan(true))
+}
+
+func TestNullableDecimalAmount(t *testing.T) {
+	// Non-null round-trips through JSON as a number.
+	n := NullableDecimalAmountFrom(NewDecimalAmount(123456, 2))
+	data, err := json.Marshal(n)
+	require.NoError(t, err)
+	assert.Equal(t, "1234.56", string(data))
+
+	// Null marshals to JSON null.
+	var null NullableDecimalAmount
+	data, err = json.Marshal(null)
+	require.NoError(t, err)
+	assert.Equal(t, "null", string(data))
+
+	// FromPtr with nil is null.
+	assert.True(t, NullableDecimalAmountFromPtr(nil).IsNull())
+	a := NewDecimalAmount(1, 0)
+	assert.True(t, NullableDecimalAmountFromPtr(&a).IsNotNull())
+
+	// SQL Value/Scan through the nullable wrapper.
+	v, err := n.Value()
+	require.NoError(t, err)
+	assert.Equal(t, "1234.56", v)
+
+	var scanned NullableDecimalAmount
+	require.NoError(t, scanned.Scan("9.99"))
+	assert.True(t, scanned.IsNotNull())
+	assert.Equal(t, "9.99", scanned.Get().String())
+
+	require.NoError(t, scanned.Scan(nil))
+	assert.True(t, scanned.IsNull())
+}
+
+func TestDecimalAmount_ScanString(t *testing.T) {
+	var a DecimalAmount
+	require.NoError(t, a.ScanString("1.234,56", true))
+	assert.Equal(t, "1234.56", a.String())
+	assert.Error(t, a.ScanString("not a number", false))
+}
+
+func TestDecimalAmountFromFloat(t *testing.T) {
+	a, err := DecimalAmountFromFloat(1234.567, 2, RoundHalfAwayFromZero)
+	require.NoError(t, err)
+	assert.Equal(t, "1234.57", a.String())
+
+	// Exact float value is rounded per mode: 0.5 is exactly representable.
+	half, err := DecimalAmountFromFloat(0.5, 0, RoundHalfToEven)
+	require.NoError(t, err)
+	assert.Equal(t, "0", half.String()) // 0.5 -> 0 (even)
+	half, err = DecimalAmountFromFloat(0.5, 0, RoundHalfAwayFromZero)
+	require.NoError(t, err)
+	assert.Equal(t, "1", half.String())
+
+	_, err = DecimalAmountFromFloat(1, MaxDecimalAmountScale+1, RoundHalfAwayFromZero)
+	assert.Error(t, err)
+}
+
+// TestDecimalAmount_MarshalJSONValidNumber guards that MarshalJSON always emits
+// a token the standard library re-parses as the same number.
+func TestDecimalAmount_MarshalJSONValidNumber(t *testing.T) {
+	for _, a := range []DecimalAmount{
+		NewDecimalAmount(0, 0),
+		NewDecimalAmount(-5, 3),
+		NewDecimalAmount(maxDecimalAmountCoefficient, 2),
+	} {
+		data, err := json.Marshal(a)
+		require.NoError(t, err)
+		assert.True(t, json.Valid(data), "invalid JSON %q", data)
+		assert.False(t, bytes.HasPrefix(data, []byte(`"`)), "should be a number, got %q", data)
+	}
+}
+
+func TestDecimalAmount_sentinels(t *testing.T) {
+	nan := DecimalAmountNaN()
+	posInf := DecimalAmountInf(1)
+	negInf := DecimalAmountInf(-1)
+	fin := NewDecimalAmount(150, 2)
+
+	// Predicates.
+	for _, s := range []DecimalAmount{nan, posInf, negInf} {
+		assert.False(t, s.IsFinite())
+		assert.False(t, s.Valid())
+		assert.False(t, s.IsZero())
+	}
+	assert.True(t, fin.IsFinite())
+	assert.True(t, nan.IsNaN())
+	assert.True(t, posInf.IsInf(1))
+	assert.True(t, posInf.IsInf(0))
+	assert.False(t, posInf.IsInf(-1))
+	assert.True(t, negInf.IsInf(-1))
+	assert.False(t, nan.IsInf(0))
+
+	// Sign/Signbit.
+	assert.Equal(t, 1, posInf.Sign())
+	assert.Equal(t, -1, negInf.Sign())
+	assert.Equal(t, 0, nan.Sign())
+	assert.True(t, negInf.Signbit())
+
+	// Neg/Abs.
+	assert.True(t, posInf.Neg().IsInf(-1))
+	assert.True(t, negInf.Abs().IsInf(1))
+	assert.True(t, nan.Neg().IsNaN())
+	assert.True(t, nan.Abs().IsNaN())
+
+	// Strings.
+	assert.Equal(t, "NaN", nan.String())
+	assert.Equal(t, "Inf", posInf.String())
+	assert.Equal(t, "-Inf", negInf.String())
+	assert.Equal(t, "money.DecimalAmountInf(1)", fmt.Sprintf("%#v", posInf))
+	assert.Equal(t, "Inf", fmt.Sprintf("%.2f", posInf))
+	assert.Equal(t, "  -Inf", fmt.Sprintf("%6s", negInf))
+
+	// Total order via Cmp: -Inf < finite < +Inf < NaN.
+	assert.Equal(t, -1, negInf.Cmp(fin))
+	assert.Equal(t, -1, fin.Cmp(posInf))
+	assert.Equal(t, -1, posInf.Cmp(nan))
+	assert.Equal(t, 0, nan.Cmp(DecimalAmountNaN()))
+	assert.True(t, posInf.Equal(DecimalAmountInf(1)))
+
+	// Propagation.
+	assert.True(t, posInf.Add(fin).IsInf(1))
+	assert.True(t, posInf.Add(negInf).IsNaN()) // +Inf + -Inf
+	assert.True(t, nan.Add(fin).IsNaN())
+	assert.True(t, posInf.Mul(NewDecimalAmount(0, 0), RoundHalfAwayFromZero).IsNaN()) // Inf * 0
+	assert.True(t, nan.Mul(fin, RoundHalfAwayFromZero).IsNaN())
+	assert.True(t, posInf.Mul(negInf, RoundHalfAwayFromZero).IsInf(-1)) // +Inf * -Inf
+	assert.True(t, negInf.Mul(fin, RoundHalfAwayFromZero).IsInf(-1))    // -Inf * positive finite
+	assert.True(t, posInf.Div(posInf, RoundHalfAwayFromZero).IsNaN())   // Inf / Inf
+	assert.True(t, fin.Div(posInf, RoundHalfAwayFromZero).IsZero())     // finite / Inf
+	assert.True(t, negInf.Div(fin, RoundHalfAwayFromZero).IsInf(-1))    // -Inf / positive finite
+	assert.True(t, nan.Div(fin, RoundHalfAwayFromZero).IsNaN())
+	assert.True(t, nan.RoundToCents(RoundHalfAwayFromZero).IsNaN())
+
+	// MulInt on non-finite: NaN propagates, Inf × 0 is NaN, sign follows n.
+	assert.True(t, nan.MulInt(5).IsNaN())
+	assert.True(t, posInf.MulInt(0).IsNaN())
+	assert.True(t, posInf.MulInt(3).IsInf(1))
+	assert.True(t, posInf.MulInt(-3).IsInf(-1))
+
+	// JSON round-trips through quoted strings.
+	for _, s := range []DecimalAmount{nan, posInf, negInf} {
+		data, err := json.Marshal(s)
+		require.NoError(t, err)
+		assert.True(t, json.Valid(data), "invalid JSON %q", data)
+		var got DecimalAmount
+		require.NoError(t, json.Unmarshal(data, &got))
+		assert.Equal(t, s, got, "JSON round-trip of %s", s)
+	}
+
+	// Binary round-trips.
+	for _, s := range []DecimalAmount{nan, posInf, negInf} {
+		data, err := s.MarshalBinary()
+		require.NoError(t, err)
+		var got DecimalAmount
+		require.NoError(t, got.UnmarshalBinary(data))
+		assert.Equal(t, s, got, "binary round-trip of %s", s)
+	}
+
+	// SQL uses PostgreSQL numeric literals and round-trips.
+	for _, tc := range []struct {
+		in  DecimalAmount
+		sql string
+	}{
+		{posInf, "Infinity"},
+		{negInf, "-Infinity"},
+		{nan, "NaN"},
+	} {
+		v, err := tc.in.Value()
+		require.NoError(t, err)
+		assert.Equal(t, tc.sql, v)
+		var scanned DecimalAmount
+		require.NoError(t, scanned.Scan(tc.sql))
+		assert.Equal(t, tc.in, scanned, "SQL round-trip of %s", tc.in)
+	}
+}
+
+func TestDecimalAmount_accessors(t *testing.T) {
+	assert.Equal(t, "42", DecimalAmountFromInt(42).String())
+
+	pos := NewDecimalAmount(150, 2)
+	neg := NewDecimalAmount(-150, 2)
+	zero := DecimalAmount{}
+
+	assert.Equal(t, +1, pos.Sign())
+	assert.Equal(t, -1, neg.Sign())
+	assert.Equal(t, 0, zero.Sign())
+
+	assert.False(t, pos.Signbit())
+	assert.True(t, neg.Signbit())
+
+	assert.Equal(t, pos, pos.Abs())
+	assert.Equal(t, pos, neg.Abs())
+	assert.Equal(t, neg, pos.Neg())
+
+	assert.Equal(t, pos, *pos.Ptr())
+
+	// JSONSchema describes a numeric type.
+	assert.Equal(t, "number", DecimalAmount{}.JSONSchema().Type)
+}
+
+func TestDecimalAmount_AmountInterop(t *testing.T) {
+	d := NewDecimalAmount(123456, 2)
+	assert.InDelta(t, 1234.56, float64(d.Amount()), 1e-9)
+
+	got, err := DecimalAmountFromAmount(Amount(1234.567), 2, RoundHalfAwayFromZero)
+	require.NoError(t, err)
+	assert.Equal(t, "1234.57", got.String())
+
+	// Amount.DecimalAmount method mirror.
+	assert.Equal(t, "1234.57", Amount(1234.567).DecimalAmount(2, RoundHalfAwayFromZero).String())
+	// A non-finite Amount maps to the matching sentinel instead of panicking.
+	assert.True(t, Amount(math.Inf(1)).DecimalAmount(2, RoundHalfAwayFromZero).IsInf(1))
+	assert.True(t, Amount(math.NaN()).DecimalAmount(2, RoundHalfAwayFromZero).IsNaN())
+
+	// Round-trip Amount -> DecimalAmount -> Amount at 2 decimals.
+	back, err := DecimalAmountFromAmount(d.Amount(), 2, RoundHalfAwayFromZero)
+	require.NoError(t, err)
+	assert.True(t, d.Equal(back))
+}
+
+func TestDecimalAmount_RateInterop(t *testing.T) {
+	price := NewDecimalAmount(10000, 2) // 100.00
+
+	// 100.00 * 1.19 VAT rate -> 119.00 at 2 decimals.
+	assert.Equal(t, "119.00", price.MultipliedByRate(Rate(1.19), 2, RoundHalfAwayFromZero).String())
+	// Reverse: 119.00 / 1.19 -> 100.00.
+	assert.Equal(t, "100.00", NewDecimalAmount(11900, 2).DividedByRate(Rate(1.19), 2, RoundHalfAwayFromZero).String())
+	// 19% of 100.00 -> 19.00.
+	assert.Equal(t, "19.00", price.Percentage(19, 2, RoundHalfAwayFromZero).String())
+	// Result scale is the requested one.
+	assert.Equal(t, 4, price.MultipliedByRate(Rate(1.19), 4, RoundHalfAwayFromZero).Scale())
+
+	// Dividing by a zero rate yields +Inf instead of panicking.
+	assert.True(t, price.DividedByRate(Rate(0), 2, RoundHalfAwayFromZero).IsInf(1))
+}

--- a/money/decimalamount_test.go
+++ b/money/decimalamount_test.go
@@ -222,9 +222,79 @@ func TestDecimalAmount_AddSub(t *testing.T) {
 	z := NewDecimalAmount(5, 2).Add(NewDecimalAmount(-5, 2))
 	assert.True(t, z.IsZero())
 
-	// Overflow yields +Inf (or -Inf for negative operands).
+	// Overflow of the integer part yields +Inf (or -Inf for negative operands).
 	assert.True(t, NewDecimalAmount(maxDecimalAmountCoefficient, 0).Add(NewDecimalAmount(maxDecimalAmountCoefficient, 0)).IsInf(1))
 	assert.True(t, NewDecimalAmount(minDecimalAmountCoefficient, 0).Add(NewDecimalAmount(minDecimalAmountCoefficient, 0)).IsInf(-1))
+}
+
+// TestDecimalAmount_AddScaleMismatch guards the regression where aligning a
+// representable sum to the larger scale overflowed to ±Inf.
+func TestDecimalAmount_AddScaleMismatch(t *testing.T) {
+	// x + 0 is identity even when the zero carries a large scale (used to
+	// return +Inf because 2.5 is not representable at scale 18).
+	x := NewDecimalAmount(25, 1) // 2.5
+	sum := x.Add(NewDecimalAmount(0, 18))
+	assert.True(t, sum.IsFinite(), "x + 0 must stay finite")
+	assert.True(t, x.Equal(sum), "x + 0 must equal x, got %s", sum)
+
+	// Near-cancellation of large opposite-sign operands yields the small sum.
+	got := NewDecimalAmount(28823037615171175, 0).Add(NewDecimalAmount(-288230376151711743, 1))
+	assert.Equal(t, "0.7", got.String())
+
+	// Sub inherits the fix.
+	assert.True(t, x.Equal(x.Sub(NewDecimalAmount(0, 18))))
+}
+
+// TestDecimalAmount_AddOracle fuzzes Add against a big.Rat reference, including
+// the representability boundary for the ±Inf result.
+func TestDecimalAmount_AddOracle(t *testing.T) {
+	rng := rand.New(rand.NewSource(2))
+	randDec := func() DecimalAmount {
+		return NewDecimalAmount(rng.Int63n(2*maxDecimalAmountCoefficient+1)-maxDecimalAmountCoefficient, rng.Intn(MaxDecimalAmountScale+1))
+	}
+	toRat := func(d DecimalAmount) *big.Rat {
+		r := new(big.Rat).SetInt64(d.Coefficient())
+		return r.Quo(r, new(big.Rat).SetInt(new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(d.Scale())), nil)))
+	}
+	maxc := big.NewInt(maxDecimalAmountCoefficient)
+	representable := func(want *big.Rat) bool {
+		for s := 0; s <= MaxDecimalAmountScale; s++ {
+			scaled := new(big.Rat).Mul(want, new(big.Rat).SetInt(new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(s)), nil)))
+			if scaled.IsInt() {
+				return scaled.Num().CmpAbs(maxc) <= 0
+			}
+		}
+		return false
+	}
+	for range 20000 {
+		a, b := randDec(), randDec()
+		got := a.Add(b)
+		want := new(big.Rat).Add(toRat(a), toRat(b))
+		if got.IsInf(0) {
+			require.Falsef(t, representable(want), "Add(%s,%s)=Inf but %s is representable", a, b, want.FloatString(20))
+			continue
+		}
+		require.Zerof(t, toRat(got).Cmp(want), "Add(%s,%s)=%s, want %s", a, b, got, want.FloatString(20))
+	}
+}
+
+func TestDecimalAmount_ScanStringValidate(t *testing.T) {
+	var d DecimalAmount
+	// validate=true rejects non-finite input (mirrors Amount.ScanString).
+	assert.Error(t, d.ScanString("NaN", true))
+	assert.Error(t, d.ScanString("Inf", true))
+	assert.Error(t, d.ScanString("-Infinity", true))
+	// validate=false still accepts it as a sentinel.
+	require.NoError(t, d.ScanString("NaN", false))
+	assert.True(t, d.IsNaN())
+	// Finite values pass validation.
+	require.NoError(t, d.ScanString("1.23", true))
+	assert.Equal(t, "1.23", d.String())
+
+	var ca CurrencyDecimalAmount
+	assert.Error(t, ca.ScanString("EUR Inf", true))
+	require.NoError(t, ca.ScanString("EUR 1.23", true))
+	assert.Equal(t, "1.23", ca.Amount.String())
 }
 
 func TestDecimalAmount_MulInt(t *testing.T) {
@@ -422,12 +492,14 @@ func TestDecimalAmount_Binary(t *testing.T) {
 
 	var got DecimalAmount
 	assert.Error(t, got.UnmarshalBinary([]byte{1, 2, 3}))
-	// Any scale > MaxDecimalAmountScale is non-finite; a scale-19 zero
-	// coefficient canonicalizes to NaN rather than being rejected.
-	nonCanonical := make([]byte, 8)
-	nonCanonical[7] = 19
-	require.NoError(t, got.UnmarshalBinary(nonCanonical))
-	assert.True(t, got.IsNaN())
+	// A non-canonical scale (19..30 is never emitted) is rejected as corrupt.
+	badScale := make([]byte, 8)
+	badScale[7] = 19
+	assert.Error(t, got.UnmarshalBinary(badScale))
+	// An out-of-range coefficient (-2^58, one below the valid minimum) is
+	// rejected so it can never break the Neg/Abs invariant. 0x80.. decodes to
+	// scale 0, coefficient -2^58.
+	assert.Error(t, got.UnmarshalBinary([]byte{0x80, 0, 0, 0, 0, 0, 0, 0}))
 }
 
 func TestDecimalAmount_SQL(t *testing.T) {
@@ -779,8 +851,11 @@ func TestDecimalAmount_accessors(t *testing.T) {
 
 	assert.Equal(t, pos, *pos.Ptr())
 
-	// JSONSchema describes a numeric type.
-	assert.Equal(t, "number", DecimalAmount{}.JSONSchema().Type)
+	// JSONSchema allows a number (finite) or a string (non-finite tokens).
+	schema := DecimalAmount{}.JSONSchema()
+	require.Len(t, schema.OneOf, 2)
+	assert.Equal(t, "number", schema.OneOf[0].Type)
+	assert.Equal(t, "string", schema.OneOf[1].Type)
 }
 
 func TestDecimalAmount_AmountInterop(t *testing.T) {

--- a/money/rate.go
+++ b/money/rate.go
@@ -126,7 +126,7 @@ func (r Rate) RoundToDecimals(decimals int) Rate {
 	return Rate(math.Round(float64(r)*pow) / pow)
 }
 
-// Format formats the Rate similar to strconv.FormatFloat with the 'f' format option,
+// FormatSep formats the Rate similar to strconv.FormatFloat with the 'f' format option,
 // but with decimalSep as decimal separator instead of a point
 // and optional grouping of the integer part.
 // Valid values for decimalSep are '.' and ','.
@@ -138,7 +138,7 @@ func (r Rate) RoundToDecimals(decimals int) Rate {
 // Note that the last digit is not rounded!
 // The special precision -1 uses the smallest number of digits
 // necessary such that ParseFloat will return f exactly.
-func (r Rate) Format(thousandsSep, decimalSep rune, precision int) string {
+func (r Rate) FormatSep(thousandsSep, decimalSep rune, precision int) string {
 	return float.Format(float64(r), thousandsSep, decimalSep, precision, true)
 }
 

--- a/strfmt/formatter.go
+++ b/strfmt/formatter.go
@@ -36,14 +36,14 @@ type MoneyFormat struct {
 // FormatAmount formats a monetary amount as a string using the
 // thousands separator, decimal separator, and precision defined in format.
 func (format *MoneyFormat) FormatAmount(amount money.Amount) string {
-	return amount.Format(format.ThousandsSep, format.DecimalSep, format.Precision)
+	return amount.FormatSep(format.ThousandsSep, format.DecimalSep, format.Precision)
 }
 
 // FormatCurrencyAmount formats a currency-tagged monetary amount as a string,
 // placing the currency code before or after the number according to
 // format.CurrencyFirst, and applying the configured separators and precision.
 func (format *MoneyFormat) FormatCurrencyAmount(currencyAmount money.CurrencyAmount) string {
-	return currencyAmount.Format(format.CurrencyFirst, format.ThousandsSep, format.DecimalSep, format.Precision)
+	return currencyAmount.FormatSep(format.CurrencyFirst, format.ThousandsSep, format.DecimalSep, format.Precision)
 }
 
 // EnglishFloatFormat returns a float.FormatDef using a dot as the decimal


### PR DESCRIPTION
## Summary

Adds an exact fixed-point monetary type to the `money` package as an alternative to the existing `float64`-based `Amount`, designed around one rule: **calculate exactly, round once at the end.**

### `DecimalAmount`

Value is `Coefficient × 10^-Scale` packed into a single `int64` (low 5 bits = scale 0–18, high 59 bits = signed coefficient, ~18 significant digits). Finite values are exact — `0.10` and `99999999999999.99` keep every digit — and each value carries its own scale. NaN/±Inf are encoded via a reserved scale, and arithmetic never panics on data: overflow → ±Inf, `x/0` → ±Inf, `0/0` → NaN, NaN propagates.

Arithmetic keeps full precision and rounds only when a result genuinely exceeds the representable precision:

- `Add`/`Sub` use the larger operand scale.
- `Mul` result scale is the sum of the operand scales (exact); it strips exact trailing zeros and rounds once, at the largest scale that still fits, only when the product needs more than 18 places.
- `Div` returns terminating quotients exactly (down to the preferred scale `a.Scale()-b.Scale()`) and rounds a non-terminating quotient once at the largest representable scale.
- The float64-`Rate` helpers `MultipliedByRate`/`DividedByRate`/`Percentage` return the shortest exact decimal of the `float64` result for the caller to round once at the end.

All of this runs on 128-bit integer multiply/divide (`math/bits`, no heap). 8 rounding modes. Full `fmt` / `sql` / `json` / `encoding.Text|Binary` / `JSONSchema` integration, plus `NullableDecimalAmount` (construct with `a.Nullable()`).

Generic conversion: `DecimalAmountFrom[T](v)` accepts any integer or float type (incl. `Amount`/`Rate`) — integers convert exactly at scale 0, floats via their shortest round-tripping decimal, out-of-range maps to ±Inf.

### `CurrencyDecimalAmount`

The exact counterpart of `CurrencyAmount`, pairing a `Currency` with a `DecimalAmount`. Formatting uses the amount's own scale rather than forcing two decimals.

### Rename

The `float64` formatter method `Format` on `Amount`, `Rate`, `CurrencyAmount`, and `CurrencyDecimalAmount` is renamed to `FormatSep` (it takes explicit separators), freeing the `Format` name and matching the `DecimalAmount` API.

> **Breaking (pre-v1):** callers of `Amount.Format`, `Rate.Format`, `CurrencyAmount.Format`, or `CurrencyDecimalAmount.Format` must switch to `FormatSep`. `DecimalAmount.Format` now implements `fmt.Formatter` (verb-based). The module has no released tags yet, so this lands under the pre-v1.0.0 baseline.

### JSON decoding hardening

`DecimalAmount.UnmarshalJSON` now decodes the JSON string through the standard library instead of stripping the surrounding quotes by hand, so a conformant encoder that emits a digit as a `\uXXXX` escape decodes correctly. An empty string decodes to zero alongside `null`.

## Test Coverage

New code (`decimalamount.go` + `currencydecimalamount.go`): **~93.6% of statements** (all 103 functions exercised; mean per-function statement coverage 97%). Every core numeric path is covered with intent-encoding tests: exact/locale-aware parsing, all 8 rounding modes, Add/Sub/Mul/Div/MulInt, 128-bit exact multiply, cross-scale Cmp, NaN/±Inf propagation, and JSON/text/binary/SQL round-trips. `Mul` and `Div` are additionally checked against a `big.Rat` oracle over 20k randomized full-range operands, asserting the result is exact whenever the true value is representable and that rounding only ever touches the last representable digit.

Remaining gaps are low-value defensive/cosmetic branches (unreachable-in-practice overflow guards and `String`/`GoString` non-finite arms).

## Review

- **Pre-landing review (checklist):** No critical issues. This is a pure value type, so there is no SQL/query, concurrency, or shell/injection surface. The `Format`→`FormatSep` rename was traced repo-wide — every money call site is updated (remaining `.Format(` calls are `float.Format`/`date.Format`, unrelated).
- **Adversarial review (Codex, gpt-5.5, high reasoning):** `NO CRITICAL ISSUES` on the full diff — arithmetic scale alignment, Mul/Div rounding, coefficient overflow, division-by-zero, parse↔format round-trips, and marshaling all checked. `git diff --check` clean.
- **Scope:** CLEAN. All changes serve the DecimalAmount feature; the `FormatSep` rename is the intended API cleanup that frees `Format` for the new type.

## Test plan
- [x] `go build ./...` — clean
- [x] `go vet ./money/...` — clean
- [x] `go test -count=1 ./...` — green (whole repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
