### PR TITLE
fix(email): parse Date headers without seconds and no weekday prefix

### DIFF
--- a/email/utils.go
+++ b/email/utils.go
@@ -30,6 +30,8 @@ var parseDateLayouts = []string{
 	"2 Jan 2006 15:04:05 MST",
 	"Mon,  2 Jan 2006 15:04:05 MST",
 	"Mon, 2 Jan 2006 15:04 -0700",
+	"02 Jan 2006 15:04 -0700",
+	"2 Jan 2006 15:04 -0700",
 	// 2-digit year formats (RFC 850 style)
 	"02 Jan 06 15:04:05 MST",
 	"02 Jan 06 15:04:05 -0700",

--- a/email/utils_test.go
+++ b/email/utils_test.go
@@ -114,6 +114,16 @@ func Test_parseDate(t *testing.T) {
 			want: time.Date(2026, 2, 23, 11, 42, 0, 0, cetLocation),
 		},
 		{
+			name: "27 Apr 2026 11:16 -0000",
+			date: "27 Apr 2026 11:16 -0000",
+			want: time.Date(2026, 4, 27, 11, 16, 0, 0, time.UTC),
+		},
+		{
+			name: "8 Apr 2026 11:16 -0000",
+			date: "8 Apr 2026 11:16 -0000",
+			want: time.Date(2026, 4, 8, 11, 16, 0, 0, time.UTC),
+		},
+		{
 			name: "24 Feb 26 18:52:49 GMT",
 			date: "24 Feb 26 18:52:49 GMT",
 			want: time.Date(2026, 2, 24, 18, 52, 49, 0, time.UTC),


### PR DESCRIPTION
## Problem

`ParseMIMEMessage` failed on the `Date` header `27 Apr 2026 11:16 -0000`:

```
can't parse email header 'Date': unable to parse email Date "27 Apr 2026 11:16 -0000"
```

That shape is: day, month, year, and an `HH:MM` offset with **no seconds** and **no weekday prefix**. In `email/utils.go` the only no-seconds layout in `parseDateLayouts` was `"Mon, 2 Jan 2006 15:04 -0700"`, which requires a `Mon, ` weekday. So this input fell through to the error. Since #13, that surfaces as a joined non-fatal error and the parsed `Date` is dropped.

## Fix

Add the two missing layouts, matching the existing convention of listing both a zero-padded and an unpadded day variant:

```go
"02 Jan 2006 15:04 -0700",
"2 Jan 2006 15:04 -0700",
```

`-0000` parses correctly as UTC.

## Tests

Added two cases to `Test_parseDate` — the reported input (`27 Apr 2026 11:16 -0000`) and a single-digit-day variant (`8 Apr 2026 11:16 -0000`). `go build ./...`, `go vet ./email/...`, and `go test ./email/...` all pass.

## Asana

BUG: unable to parse email Date — https://app.asana.com/1/201241326692307/project/1138407765982241/task/1216410860228770